### PR TITLE
一覧画面作成

### DIFF
--- a/backend/app/Http/Controllers/MockController.php
+++ b/backend/app/Http/Controllers/MockController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Response;
 use Carbon\Carbon;
+use Mockery\Undefined;
 
 class MockController extends Controller
 {
@@ -12,206 +13,410 @@ class MockController extends Controller
     // GET ex) http://localhost:8000/api/timetablesAcquire?date=
     public function getTimetables(Request $request)
     {
-        $timetables = [
-            [
-                'date' => '2023/04/17',
-                'dayOfWeek' => 1,
-                'isHoliday' => false,
-                'lessons' =>
+        $date = $request->date;
+        if ($date === "20230424") {
+            $timetables = [
                 [
+                    'date' => '2023/04/24',
+                    'dayOfWeek' => 1,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/25',
+                    'dayOfWeek' => 2,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/26',
+                    'dayOfWeek' => 3,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/27',
+                    'dayOfWeek' => 4,
+                    'isHoliday' => true,
+                    'holidayTitle' => '憲法記念日'
+                ],
+                [
+                    'date' => '2023/04/28',
+                    'dayOfWeek' => 5,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/29',
+                    'dayOfWeek' => 6,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/30',
+                    'dayOfWeek' => 0,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ]
                     ]
                 ]
-            ],
-            [
-                'date' => '2023/04/18',
-                'dayOfWeek' => 2,
-                'isHoliday' => false,
-                'lessons' =>
+            ];
+        } else {
+            $timetables = [
                 [
+                    'date' => '2023/04/17',
+                    'dayOfWeek' => 1,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/18',
+                    'dayOfWeek' => 2,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/19',
+                    'dayOfWeek' => 3,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/20',
+                    'dayOfWeek' => 4,
+                    'isHoliday' => true,
+                    'holidayTitle' => '憲法記念日'
+                ],
+                [
+                    'date' => '2023/04/21',
+                    'dayOfWeek' => 5,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ],
+                        [
+                            'subject' => '国語',
+                            'teacher' => '佐藤'
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/22',
+                    'dayOfWeek' => 6,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ]
+                    ]
+                ],
+                [
+                    'date' => '2023/04/23',
+                    'dayOfWeek' => 0,
+                    'isHoliday' => false,
+                    'lessons' =>
                     [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ],
+                        [
+                            'subject' => '',
+                            'teacher' => ''
+                        ]
                     ]
                 ]
-            ],
-            [
-                'date' => '2023/04/19',
-                'dayOfWeek' => 3,
-                'isHoliday' => false,
-                'lessons' =>
-                [
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ]
-                ]
-            ],
-            [
-                'date' => '2023/04/20',
-                'dayOfWeek' => 4,
-                'isHoliday' => true,
-                'holidayTitle' => '憲法記念日'
-            ],
-            [
-                'date' => '2023/04/21',
-                'dayOfWeek' => 5,
-                'isHoliday' => false,
-                'lessons' =>
-                [
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ],
-                    [
-                        'subject' => '国語',
-                        'teacher' => '佐藤'
-                    ]
-                ]
-            ],
-            [
-                'date' => '2023/04/22',
-                'dayOfWeek' => 6,
-                'isHoliday' => false,
-                'lessons' =>
-                [
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ]
-                ]
-            ],
-            [
-                'date' => '2023/04/23',
-                'dayOfWeek' => 0,
-                'isHoliday' => false,
-                'lessons' =>
-                [
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ],
-                    [
-                        'subject' => '',
-                        'teacher' => ''
-                    ]
-                ]
-            ]
-        ];
+            ];
+        }
 
         return Response::json($timetables);
     }

--- a/backend/app/Http/Controllers/MockController.php
+++ b/backend/app/Http/Controllers/MockController.php
@@ -16,7 +16,7 @@ class MockController extends Controller
             [
                 'date' => '2023/04/17',
                 'dayOfWeek' => 1,
-                'isHoliday' => 'false',
+                'isHoliday' => false,
                 'lessons' =>
                 [
                     [
@@ -48,7 +48,7 @@ class MockController extends Controller
             [
                 'date' => '2023/04/18',
                 'dayOfWeek' => 2,
-                'isHoliday' => 'false',
+                'isHoliday' => false,
                 'lessons' =>
                 [
                     [
@@ -80,7 +80,7 @@ class MockController extends Controller
             [
                 'date' => '2023/04/19',
                 'dayOfWeek' => 3,
-                'isHoliday' => 'false',
+                'isHoliday' => false,
                 'lessons' =>
                 [
                     [
@@ -112,13 +112,13 @@ class MockController extends Controller
             [
                 'date' => '2023/04/20',
                 'dayOfWeek' => 4,
-                'isHoliday' => 'true',
+                'isHoliday' => true,
                 'holidayTitle' => '憲法記念日'
             ],
             [
                 'date' => '2023/04/21',
                 'dayOfWeek' => 5,
-                'isHoliday' => 'false',
+                'isHoliday' => false,
                 'lessons' =>
                 [
                     [
@@ -150,7 +150,7 @@ class MockController extends Controller
             [
                 'date' => '2023/04/22',
                 'dayOfWeek' => 6,
-                'isHoliday' => 'false',
+                'isHoliday' => false,
                 'lessons' =>
                 [
                     [
@@ -182,7 +182,7 @@ class MockController extends Controller
             [
                 'date' => '2023/04/23',
                 'dayOfWeek' => 0,
-                'isHoliday' => 'false',
+                'isHoliday' => false,
                 'lessons' =>
                 [
                     [

--- a/backend/app/Http/Controllers/MockController.php
+++ b/backend/app/Http/Controllers/MockController.php
@@ -14,7 +14,7 @@ class MockController extends Controller
     public function getTimetables(Request $request)
     {
         $date = $request->date;
-        if ($date === "20230424") {
+        if ($date === "2023-04-24") {
             $timetables = [
                 [
                     'date' => '2023/04/24',

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -1,15 +1,43 @@
 <template>
   <default-layout page-name="教師用ページ">
-    <!-- html記述場所 -->
-    <TimetableComponent :timetables="timetables"></TimetableComponent>
+    <div :class="timeconsole()"></div>
+    <section class="container">
+      <!-- html記述場所 -->
+      <!--三角ボタン-->
+      <div class="triangle-button-area">
+        <div class="triangle-button">
+          <!--先週-->
+          <button class="triangle-left" href="#"></button>
+          <!--来週-->
+          <a class="triangle-right" href="#"></a>
+        </div>
+      </div>
+      <div class="main">
+        <!--ボタン-->
+        <div class="timetable-button-area">
+          <button @click="getThisWeekTimetables">今週の時間割</button>
+          <button>日付選択</button>
+          <button @click="goToRegisterPage">時間割登録</button>
+          <button @click="goToStudentPage">生徒用画面確認</button>
+          <button @click="logout">ログアウト</button>
+        </div>
+        <!--時間割-->
+        <div>
+          <TimetableComponent :timetables="timetables"></TimetableComponent>
+        </div>
+      </div>
+    </section>
   </default-layout>
 </template>
 
 <script lang="ts" setup>
-import { Timetable } from '~~/types/response/timetablesAcquireResponse'
+import { Timetable, Lesson } from '~~/types/response/timetablesAcquireResponse'
+import { format } from 'date-fns'
+import { onMounted } from 'vue'
 
+const route = useRoute()
 /* 検証用オブジェクト */
-const timetables: Timetable[] = [
+const timetables2: Timetable[] = [
   {
     date: '2023-04-17',
     dayOfWeek: 1,
@@ -154,6 +182,102 @@ const timetables: Timetable[] = [
     ],
   },
 ]
+
+//APIから時間割取得
+console.log(' http://localhost:8000/api/timetablesAcquire?date=' + route.query.date)
+
+const { data: response } = useFetch<Timetable[]>(
+  ' http://localhost:8000/api/timetablesAcquire?date=' + route.query.date,
+  {}
+)
+
+const timetables = ref<Timetable[]>([])
+
+if (response.value != null) {
+  timetables.value = response.value
+}
+
+//登録画面遷移
+function goToRegisterPage() {
+  navigateTo({ path: '/timetableRegister' })
+}
+
+//生徒用画面遷移
+function goToStudentPage() {
+  window.open('/studentHome', '_blank')
+}
+
+//今週の時間割表示
+function getThisWeekTimetables() {
+  //月曜日を求める
+  let date = new Date()
+  while (true) {
+    if (date.getDay() == 1) break
+    date = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1)
+  }
+  const dateMonday = format(date, 'yyyyMMdd')
+  navigateTo({
+    path: '/home',
+    query: {
+      date: 2021,
+    },
+  })
+}
+
+//ログアウト
+function logout() {}
+
+function timeconsole() {
+  console.log('表示')
+}
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.container {
+  margin: 0 36px 0 0;
+}
+/* 三角関連 */
+.triangle-button-area {
+  height: 120px;
+  padding-top: 48px;
+  display: flex;
+  justify-content: flex-end;
+}
+.triangle-button {
+  width: 160px;
+  height: 56px;
+}
+.triangle-left {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 25px 48px 25px 0;
+  border-color: transparent #5160ae transparent transparent;
+  position: absolute;
+}
+.triangle-right {
+  // margin: 30px 0 0px 90px;
+  margin-left: 104px;
+  margin-right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 21px 0 21px 48px;
+  border-color: transparent transparent transparent #5160ae;
+  position: absolute;
+}
+/* 下部 */
+.main {
+  display: flex;
+}
+button {
+  margin-bottom: 24px;
+}
+.timetable-button-area {
+  // width: 204px;
+  width: 14%;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+</style>

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -221,9 +221,12 @@ function displayRightButton() {
 
 //前週ボタン押下時
 function getLastWeekTimetable() {
+  console.log('old' + oldestDate)
+  console.log('display' + displayDate)
+
   if (oldestDate <= displayDate) {
     displayDate.setDate(displayDate.getDate() - 7)
-    const lastWeekDate = format(displayDate, 'yyyyMMdd')
+    const lastWeekDate = format(displayDate, 'yyyy-MM-dd')
     navigateTo({
       path: '/home',
       query: {
@@ -238,7 +241,7 @@ function getLastWeekTimetable() {
 function getNextWeekTimetable() {
   if (latestDate >= displayDate) {
     displayDate.setDate(displayDate.getDate() + 7)
-    const nextWeekDate = format(displayDate, 'yyyyMMdd')
+    const nextWeekDate = format(displayDate, 'yyyy-MM-dd')
     navigateTo({
       path: '/home',
       query: {
@@ -256,7 +259,7 @@ function getTimetableData() {
     view = getMonday(new Date())
   } else {
     //渡されたクエリを一度月曜判定入れる
-    view = getMonday(parse(String(route.query.date), 'yyyyMMdd', new Date()))
+    view = getMonday(parse(String(route.query.date), 'yyyy-MM-dd', new Date()))
     //月曜じゃなかったらURL変更、再度読み込み
     if (!(view === String(route.query.date))) {
       navigateTo({
@@ -267,7 +270,7 @@ function getTimetableData() {
       })
     }
   }
-  displayDate = parse(view, 'yyyyMMdd', new Date())
+  displayDate = parse(view, 'yyyy-MM-dd', new Date())
   const { data: response } = useFetch<Timetable[]>(' http://localhost:8000/api/timetablesAcquire?date=' + view, {})
 
   if (response.value != null) {
@@ -303,7 +306,7 @@ function getMonday(date: Date) {
     if (date.getDay() == 1) break
     date = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1)
   }
-  const thisWeekMonday = format(date, 'yyyyMMdd')
+  const thisWeekMonday = format(date, 'yyyy-MM-dd')
   return thisWeekMonday
 }
 

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -263,12 +263,18 @@ async function getTimetableData() {
     }
   }
   displayDate = parse(view.value, 'yyyy-MM-dd', new Date())
-  const { data: response } = await useFetch<Timetable[]>(' http://localhost:8000/api/timetablesAcquire/', {
-    query: { date: view.value },
-  })
+  const config = useRuntimeConfig()
+  try {
+    const { data: response } = await useFetch<Timetable[]>('/api/timetablesAcquire/', {
+      baseURL: config.public.apiUrl,
+      query: { date: view.value },
+    })
 
-  if (response.value != null) {
-    timetables.value = response.value
+    if (response.value != null) {
+      timetables.value = response.value
+    }
+  } catch (e) {
+    console.error(e)
   }
 }
 

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -263,10 +263,9 @@ async function getTimetableData() {
     }
   }
   displayDate = parse(view.value, 'yyyy-MM-dd', new Date())
-  const { data: response } = await useFetch<Timetable[]>(
-    ' http://localhost:8000/api/timetablesAcquire?date=' + view.value,
-    {}
-  )
+  const { data: response } = await useFetch<Timetable[]>(' http://localhost:8000/api/timetablesAcquire/', {
+    query: { date: view.value },
+  })
 
   if (response.value != null) {
     timetables.value = response.value

--- a/frontend/types/response/timetablesAcquireResponse.ts
+++ b/frontend/types/response/timetablesAcquireResponse.ts
@@ -6,7 +6,7 @@ export interface Timetable {
   holidayTitle?: string
 }
 
-interface Lesson {
+export interface Lesson {
   subject: string
   teacher: string
 }


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-25

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

・一覧画面の作成
→ボタンのデザインはカレンダーダイアログのものと合わせたいと考えているので現在は手を付けていません。
→ログアウト処理はログインAPIを確認してから記述したいと考えているので現在は手を付けていません。
![image](https://user-images.githubusercontent.com/130024690/234789272-5cd9a2a7-492e-4fc6-94ae-fea748faa1eb.png)

・MookControllerのデータ変更

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
