### PR TITLE
実装/フロント_生徒用画面

### DIFF
--- a/frontend/assets/scss/main.scss
+++ b/frontend/assets/scss/main.scss
@@ -60,7 +60,6 @@ body {
 .font-size-xl {
   font-family: $font;
   font-weight: $font-weight;
-  font-size: 36px;
 }
 
 .white {
@@ -79,4 +78,9 @@ body {
   border: solid 3px #5160ae;
   margin-top: 24px;
   margin-left: 20px;
+}
+@media screen and (min-width: 768px) {
+  .font-size-xl {
+    font-size: 36px;
+  }
 }

--- a/frontend/assets/scss/timetable.scss
+++ b/frontend/assets/scss/timetable.scss
@@ -1,4 +1,5 @@
 //PC用scss
+@media screen and (min-width: 768px) {
 .timetable {
   writing-mode: vertical-lr;
   border-collapse: collapse;
@@ -58,17 +59,21 @@
   background-color: #5160ae;
 }
 
+}
+
 //モバイル用scss
 @media only screen and (max-width: 767px) {
   .timetable {
     writing-mode: vertical-lr;
     border-collapse: collapse;
     table-layout: fixed;
-    width: 360px;
+    max-width: 360px;
+    width: 100%;
     height: 292px;
     background-color: #ffffff;
     box-shadow: 0 0 0 1px #333 inset;
     font-size: 14px;
+    margin: 0 auto;
   }
   .horizontal-writing {
     box-shadow: 0 0 0 1px #333 inset;
@@ -76,17 +81,20 @@
     word-break: break-word;
   }
   .vertical-head {
-    width: 24px;
+    max-width: 24px;
+    width: 100%;
     height: 36px;
   }
   .dayOfWeek-head {
-    width: 24px;
+    max-width: 24px;
+    width: 100%;
     height: 16px;
   }
 
   .lesson-cell {
     text-align: center;
-    width: 48px;
+    max-width: 48px;
+    width: 100%;
     height: 40px;
     font-weight: bold;
   }
@@ -113,12 +121,14 @@
   /*　日付 */
 
   .date-cell {
-    width: 48px;
+    max-width: 48px;
+    width: 100%;
     height: 36px;
     word-break: break-word;
   }
   .date-holiday-cell {
-    width: 48px;
+    max-width: 48px;
+    width: 100%;
     height: 36px;
     background-color: #f4c9c9;
   }
@@ -127,7 +137,7 @@
   }
   .date-holiday-cell .font-size-l,
   .date-cell .font-size-l {
-    font-size: 10px;
+    font-size: 8px;
   }
   .date-holiday-cell .font-size-m,
   .font-size-s {
@@ -136,14 +146,16 @@
   /*　時限 */
 
   .period-cell {
-    width: 24px;
+    max-width: 24px;
+    width: 100%;
     height: 40px;
   }
   /*曜日 */
 
   .dayOfWeek-cell {
     word-break: break-word;
-    width: 48px;
+    max-width: 48px;
+    width: 100%;
     height: 16px;
     color: #ffffff;
     background-color: #5160ae;

--- a/frontend/components/header.vue
+++ b/frontend/components/header.vue
@@ -15,13 +15,28 @@ const props = defineProps({
 
 <style scoped lang="scss">
 header {
+  width: 100%;
   height: 100px;
   background-color: #89929b;
-  h1 {
-    font-style: normal;
-  }
   div {
     padding: 15px 0px 15px 100px;
+    h1 {
+      font-style: normal;
+    }
+  }
+}
+
+// モバイル用スタイル
+@media only screen and (max-width: 767px) {
+  header {
+    height: auto;
+    div {
+      margin: 0 auto;
+      padding: 15px 0px 15px 0px;
+      h1 {
+        text-align: center;
+      }
+    }
   }
 }
 </style>

--- a/frontend/pages/studentHome.vue
+++ b/frontend/pages/studentHome.vue
@@ -1,9 +1,390 @@
 <template>
-  <default-layout page-name="生徒用ページ">
-    <!-- html記述場所 -->
+  <default-layout page-name="">
+    <section class="container_ori">
+      <!-- html記述場所 -->
+      <!--三角ボタン-->
+      <div class="triangle-button-area">
+        <div class="triangle-button">
+          <!--先週-->
+          <button class="triangle-left" :disabled="displayLeftButton()" @click="getLastWeekTimetable()"></button>
+          <!--来週-->
+          <button class="triangle-right" :disabled="displayRightButton()" @click="getNextWeekTimetable()"></button>
+        </div>
+      </div>
+      <div class="main">
+        <!--ボタン-->
+        <div class="timetable-button-area">
+          <button @click="getThisWeekTimetables">今週の時間割</button>
+          <button>日付選択</button>
+        </div>
+        <!--時間割-->
+        <div>
+          <div v-show="loadingDisplay">
+            <TimetableComponent :timetables="timetables"></TimetableComponent>
+          </div>
+        </div>
+      </div>
+    </section>
   </default-layout>
 </template>
 
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import { Timetable } from '~~/types/response/timetablesAcquireResponse'
+import { format, parse } from 'date-fns'
 
-<style scoped lang="scss"></style>
+const route = useRoute()
+const timetables = ref<Timetable[]>([])
+
+/* 検証用オブジェクト */
+const timetables2: Timetable[] = [
+  {
+    date: '2023-04-17',
+    dayOfWeek: 1,
+    isHoliday: false,
+    lessons: [
+      {
+        subject: '国語',
+        teacher: '佐藤',
+      },
+      {
+        subject: '数学',
+        teacher: '鈴木鈴木',
+      },
+      {
+        subject: '理科',
+        teacher: '高橋高橋高橋',
+      },
+      {
+        subject: '社会',
+        teacher: '田中田中田中田中',
+      },
+      {
+        subject: '音楽',
+        teacher: '伊藤伊藤伊藤伊藤伊藤',
+      },
+      {
+        subject: '道徳',
+        teacher: '中村',
+      },
+    ],
+  },
+  {
+    date: '2023-04-18',
+    dayOfWeek: 2,
+    isHoliday: false,
+    lessons: [
+      {
+        subject: '数学数学数学',
+        teacher: '鈴木',
+      },
+      {
+        subject: '国語国語国語',
+        teacher: '佐藤佐藤',
+      },
+      {
+        subject: '理科理科理科',
+        teacher: '高橋高橋高橋',
+      },
+      {
+        subject: '社会社会社会',
+        teacher: '田中田中田中田中',
+      },
+      {
+        subject: '体育体育体育',
+        teacher: '大林大林大林大林大林',
+      },
+      {
+        subject: '',
+        teacher: '',
+      },
+    ],
+  },
+  {
+    date: '2023-04-19',
+    dayOfWeek: 3,
+    isHoliday: false,
+    lessons: [
+      {
+        subject: '国語国語国語国語国語',
+        teacher: '佐藤',
+      },
+      {
+        subject: '数学数学数学数学数学',
+        teacher: '鈴木鈴木',
+      },
+      {
+        subject: '理科理科理科理科理科',
+        teacher: '高橋高橋高橋',
+      },
+      {
+        subject: '社会社会社会社会社会',
+        teacher: '田中田中田中田中',
+      },
+      {
+        subject: '音楽音楽音楽音楽音楽',
+        teacher: '伊藤伊藤伊藤伊藤伊藤',
+      },
+      {
+        subject: '',
+        teacher: '',
+      },
+    ],
+  },
+  {
+    date: '2023-04-20',
+    dayOfWeek: 4,
+    isHoliday: true,
+    holidayTitle: '○○の日',
+  },
+  {
+    date: '2023-04-21',
+    dayOfWeek: 5,
+    isHoliday: true,
+    holidayTitle: '○○○○○の日',
+  },
+  {
+    date: '2023-04-22',
+    dayOfWeek: 6,
+    isHoliday: true,
+
+    holidayTitle: '天皇誕生日 振替休日',
+  },
+  {
+    date: '2023-04-23',
+    dayOfWeek: 0,
+    isHoliday: false,
+    lessons: [
+      {
+        subject: '国語',
+        teacher: '佐藤',
+      },
+      {
+        subject: '数学',
+        teacher: '鈴木',
+      },
+      {
+        subject: '理科',
+        teacher: '高橋',
+      },
+      {
+        subject: '社会',
+        teacher: '田中',
+      },
+      {
+        subject: '音楽',
+        teacher: '伊藤',
+      },
+      {
+        subject: '道徳',
+        teacher: '斎藤',
+      },
+    ],
+  },
+]
+
+//createdのときに行う処理
+const view = ref()
+const loadingDisplay = ref(false)
+let displayDate: Date
+const oldestDate = parse('20150104', 'yyyyMMdd', new Date())
+const nextYear = String(new Date().getFullYear() + 1)
+const latestString = nextYear + '1225'
+const latestDate = parse(latestString, 'yyyyMMdd', new Date())
+
+await getTimetableData()
+
+displayToggle()
+//以下function
+
+//データ取得が完了すれば時間割を表示する
+function displayToggle() {
+  loadingDisplay.value = !loadingDisplay.value
+}
+
+//前週ボタン表示
+function displayLeftButton() {
+  return oldestDate >= displayDate
+}
+//次週ボタン表示
+function displayRightButton() {
+  return latestDate <= displayDate
+}
+
+//前週ボタン押下時
+function getLastWeekTimetable() {
+  if (oldestDate <= displayDate) {
+    displayDate.setDate(displayDate.getDate() - 7)
+    const lastWeekDate = format(displayDate, 'yyyy-MM-dd')
+    navigateTo({
+      path: '/studentHome',
+      query: {
+        date: lastWeekDate,
+      },
+    })
+  } else {
+    alert('2014年の時間割は表示できません')
+  }
+}
+//次週ボタン押下時
+function getNextWeekTimetable() {
+  if (latestDate >= displayDate) {
+    displayDate.setDate(displayDate.getDate() + 7)
+    const nextWeekDate = format(displayDate, 'yyyy-MM-dd')
+    navigateTo({
+      path: '/studentHome',
+      query: {
+        date: nextWeekDate,
+      },
+    })
+  } else {
+    alert('再来年の時間割は表示できません')
+  }
+}
+//APIから時間割取得
+async function getTimetableData() {
+  //クエリなしなら今週表示
+  if (route.query.date == null) {
+    view.value = getMonday(new Date())
+  } else {
+    //渡されたクエリを一度月曜判定入れる
+    view.value = getMonday(parse(String(route.query.date), 'yyyy-MM-dd', new Date()))
+    //月曜じゃなかったらURL変更、再度読み込み
+    if (!(view.value === String(route.query.date))) {
+      navigateTo({
+        path: '/home',
+        query: {
+          date: view.value,
+        },
+      })
+      return
+    }
+  }
+  displayDate = parse(view.value, 'yyyy-MM-dd', new Date())
+  const config = useRuntimeConfig()
+  try {
+    const { data: response } = await useFetch<Timetable[]>('/api/timetablesAcquire/', {
+      baseURL: config.public.apiUrl,
+      query: { date: view.value },
+    })
+
+    if (response.value != null) {
+      timetables.value = response.value
+    }
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+//登録画面遷移
+function goToRegisterPage() {
+  navigateTo({ path: '/timetableRegister' })
+}
+
+//生徒用画面遷移
+function goToStudentPage() {
+  window.open('/studentHome', '_blank', 'noreferrer')
+}
+
+//今週の時間割表示
+function getThisWeekTimetables() {
+  let date = new Date()
+  const dateMonday: string = getMonday(date)
+  navigateTo({
+    path: '/home',
+    query: {
+      date: dateMonday,
+    },
+  })
+}
+
+//与えられた日付から月曜日を求める
+function getMonday(date: Date) {
+  while (true) {
+    if (date.getDay() == 1) break
+    date = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1)
+  }
+  const thisWeekMonday = format(date, 'yyyy-MM-dd')
+  return thisWeekMonday
+}
+
+//ログアウト処理 ログインAPIが出来次第記述
+function logout() {}
+
+//パラメータの監視。変化があればリロード
+watch(
+  () => route.query,
+  () => {
+    location.reload()
+  }
+)
+</script>
+
+<style scoped lang="scss">
+.container_ori {
+  width: 1415px;
+  margin: 0;
+  // margin: 0 36px 0 0;
+  // display: flex;
+}
+/* 三角関連 */
+.triangle-button-area {
+  height: 120px;
+  padding-top: 48px;
+  display: flex;
+  justify-content: flex-end;
+  // flex-shrink: 1;
+}
+.triangle-button {
+  width: 160px;
+  height: 56px;
+}
+.triangle-left {
+  background: transparent;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 25px 48px 25px 0;
+  border-color: transparent #5160ae transparent transparent;
+  position: absolute;
+}
+.triangle-right {
+  background: transparent;
+  margin-left: 104px;
+  margin-right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 25px 0 25px 48px;
+  border-color: transparent transparent transparent #5160ae;
+  position: absolute;
+}
+
+.triangle-left:hover,
+.triangle-right:hover {
+  filter: brightness(1.1);
+}
+.triangle-left:disabled {
+  border-color: transparent gray transparent transparent;
+  opacity: 0.3;
+  filter: brightness(0.8);
+}
+.triangle-right:disabled {
+  border-color: transparent transparent transparent gray;
+  opacity: 0.3;
+  filter: brightness(0.8);
+}
+/* 下部 */
+.main {
+  display: flex;
+}
+button {
+  margin-bottom: 24px;
+}
+.timetable-button-area {
+  // width: 204px;
+  width: 14%;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+</style>

--- a/frontend/pages/studentHome.vue
+++ b/frontend/pages/studentHome.vue
@@ -321,7 +321,7 @@ watch(
 
 <style scoped lang="scss">
 .container_ori {
-  width: 1415px;
+  width: 428px;
   margin: 0;
   // margin: 0 36px 0 0;
   // display: flex;


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-37

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
・生徒用画面の制作
・レスポンシブ対応に伴う共通cssの変更

webの見た目
![localhost_3000_studentHome(web)](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024640/d1046536-7aed-42ca-a196-bac980a168d7)
スマホ画面
![localhost_3000_studentHome(iPhone SE)](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024640/6b1400c6-60c9-405e-8429-74df11bd011b)
ウィンドウ幅が更に狭い場合は、テーブルがスクロールできるようになる
![localhost_3000_studentHome](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024640/b705c4d6-bb19-4dd5-a7ea-fd0909b28ea7)


---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
