### PR TITLE
カレンダーモーダルのバグ修正と登録画面のデザイン修正

### DIFF
--- a/frontend/assets/scss/timetable.scss
+++ b/frontend/assets/scss/timetable.scss
@@ -1,74 +1,73 @@
 //PC用scss
 @media screen and (min-width: 768px) {
-.timetable {
-  writing-mode: vertical-lr;
-  border-collapse: collapse;
-  table-layout: fixed;
-  width: 1200px;
-  height: 660px;
-  background-color: #ffffff;
-  box-shadow: 0 0 0 1px #333 inset;
-}
+  .timetable {
+    writing-mode: vertical-lr;
+    border-collapse: collapse;
+    table-layout: fixed;
+    width: 1200px;
+    height: 660px;
+    background-color: #ffffff;
+    box-shadow: 0 0 0 1px #333 inset;
+  }
 
-.register {
-  width: 1120px;
-  height: 580px;
-  margin-top: 20px;
-  margin-left: 24px;
-  position: fixed;
-  top: 220px;
-  left: 224px;
-}
-.horizontal-writing {
-  box-shadow: 0 0 0 1px #333 inset;
-  writing-mode: horizontal-tb;
-  word-break: break-word;
-}
+  .register {
+    width: 1120px;
+    height: 580px;
+    margin-top: 20px;
+    margin-left: 24px;
+    position: absolute;
+    top: 220px;
+    left: 224px;
+  }
+  .horizontal-writing {
+    box-shadow: 0 0 0 1px #333 inset;
+    writing-mode: horizontal-tb;
+    word-break: break-word;
+  }
 
-.vertical-head {
-  width: 80px;
-  height: 80px;
-}
-.dayOfWeek-head {
-  width: 80px;
-  height: 40px;
-}
-.lesson-cell {
-  text-align: center;
-  width: 160px;
-  height: 90px;
-  font-weight: bold;
-}
-/* 科目/教師*/
-.lesson-holiday-cell {
-  background-color: #f4c9c9;
-}
-.lesson-cell-box {
-  margin: 5px;
-}
-/* 日付 */
-.date-cell {
-  width: 160px;
-  height: 80px;
-  word-break: break-word;
-}
-.date-holiday-cell {
-  background-color: #f4c9c9;
-}
-/* 時限　*/
-.period-cell {
-  width: 80px;
-  height: 90px;
-}
-/* 曜日 */
-.dayOfWeek-cell {
-  word-break: break-word;
-  width: 160px;
-  height: 40px;
-  color: #ffffff;
-  background-color: #5160ae;
-}
-
+  .vertical-head {
+    width: 80px;
+    height: 80px;
+  }
+  .dayOfWeek-head {
+    width: 80px;
+    height: 40px;
+  }
+  .lesson-cell {
+    text-align: center;
+    width: 160px;
+    height: 90px;
+    font-weight: bold;
+  }
+  /* 科目/教師*/
+  .lesson-holiday-cell {
+    background-color: #f4c9c9;
+  }
+  .lesson-cell-box {
+    margin: 5px;
+  }
+  /* 日付 */
+  .date-cell {
+    width: 160px;
+    height: 80px;
+    word-break: break-word;
+  }
+  .date-holiday-cell {
+    background-color: #f4c9c9;
+  }
+  /* 時限　*/
+  .period-cell {
+    width: 80px;
+    height: 90px;
+  }
+  /* 曜日 */
+  .dayOfWeek-cell {
+    word-break: break-word;
+    width: 160px;
+    height: 40px;
+    color: #ffffff;
+    background-color: #5160ae;
+  }
 }
 
 //モバイル用scss

--- a/frontend/components/calendar-modal.vue
+++ b/frontend/components/calendar-modal.vue
@@ -27,7 +27,7 @@ import { getYear } from 'date-fns'
 const date = ref()
 
 const minDate = computed(() => new Date(2015, 0, 5))
-const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 31))
+const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 32))
 
 const props = defineProps({
   isShown: false,

--- a/frontend/components/calendar-modal.vue
+++ b/frontend/components/calendar-modal.vue
@@ -9,6 +9,7 @@
         :min-date="minDate"
         :max-date="maxDate"
         prevent-min-max-navigation
+        :enable-time-picker="false"
         :[selectionType]="''"
         inline
         auto-apply
@@ -27,7 +28,7 @@ import { getYear } from 'date-fns'
 const date = ref()
 
 const minDate = computed(() => new Date(2015, 0, 5))
-const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 32))
+const maxDate = computed(() => new Date(getYear(new Date()) + 2, 0, 1))
 
 const props = defineProps({
   isShown: false,

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -129,12 +129,12 @@ input {
 }
 
 .back-home {
-  position: fixed;
+  position: absolute;
   left: 320px;
   top: 888px;
 }
 .timetable-update {
-  position: fixed;
+  position: absolute;
   left: 960px;
   top: 888px;
 }


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-63

# 変更内容
-登録画面のカレンダーモーダルで来年の12月31日が選択できなかったバグを修正
-スクロールができるようにデザイン修正

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
