### PR TITLE
実装_日付データ関連バグ修正

### DIFF
--- a/backend/app/Http/Controllers/GetTimetablesAcquireController.php
+++ b/backend/app/Http/Controllers/GetTimetablesAcquireController.php
@@ -17,23 +17,41 @@ class GetTimetablesAcquireController extends Controller
         //responseの用意
         $timetables = [];
         $filtered_timetables = collect();
-
-        //基準となる月曜日を変数に
-        $dateMonday = $date;
+        //比較用
+        $oldestDate = strtotime('20141226');
+        $latestDate = strtotime(date("Y", strtotime(today() . +1 . ' year')) . '1231');
 
         //再来年取得
         $yearAfterNext = date("Y", strtotime(today() . +2 . ' year'));
 
-
         //年だけ取得
         $holidayDataYear = explode("-", ($date))[0];
+
         if ($holidayDataYear <= '2014' || $holidayDataYear >= $yearAfterNext) {
             $yearHolidayDatas = [];
-        } else {
+            //範囲外の場合
+            if (strtotime($date) < $oldestDate || $latestDate <= strtotime($date)) {
+                //今日のものに変更
+                $date = date("Y-m-d", strtotime(today()));
 
+                //月曜日判定
+                $dateDayOfWeek = date("w", strtotime(today()));
+                if ($dateDayOfWeek !== 1) {
+                    $date = date('Y-m-d', strtotime(- ($dateDayOfWeek - 1) . " day", strtotime($date)));
+                }
+                //値取り直し
+                $yearAfterNext = date("Y", strtotime(today() . +2 . ' year'));
+                $holidayDataYear = explode("-", ($date))[0];
+                $yearHolidayDatas = $this->getHolidays($holidayDataYear);
+            }
+        } else {
             //月曜の年の祝日データを取る
             $yearHolidayDatas = $this->getHolidays($holidayDataYear);
         }
+
+        //基準となる月曜日を変数に
+        $dateMonday = $date;
+
         list($filtered_timetables, $timetables) = $this->setDateData($yearAfterNext, $timetables, $dateMonday, $holidayDataYear, $filtered_timetables, $yearHolidayDatas);
 
         //rankedtimetable:created_atでsortdesc

--- a/backend/app/Http/Controllers/GetTimetablesAcquireController.php
+++ b/backend/app/Http/Controllers/GetTimetablesAcquireController.php
@@ -92,6 +92,12 @@ class GetTimetablesAcquireController extends Controller
                 $setData['isHoliday'] = false;
                 $setData['lessons'] = array();
             }
+            //範囲外判定
+            if ($getDateYear <= '2014' || $getDateYear >= $yearAfterNext) {
+                $setData['isunavailable'] = true;
+            } else {
+                $setData['isunavailable'] = false;
+            }
 
             array_push($timetables, $setData);
 

--- a/backend/app/Http/Controllers/GetTimetablesAcquireController.php
+++ b/backend/app/Http/Controllers/GetTimetablesAcquireController.php
@@ -18,11 +18,12 @@ class GetTimetablesAcquireController extends Controller
         $timetables = [];
         $filtered_timetables = collect();
         //比較用
+        $today = today();
         $oldestDate = strtotime('20141226');
-        $latestDate = strtotime(date("Y", strtotime(today() . +1 . ' year')) . '1231');
+        $latestDate = strtotime(date("Y", strtotime($today . +1 . ' year')) . '1231');
 
         //再来年取得
-        $yearAfterNext = date("Y", strtotime(today() . +2 . ' year'));
+        $yearAfterNext = date("Y", strtotime($today . +2 . ' year'));
 
         //年だけ取得
         $holidayDataYear = explode("-", ($date))[0];
@@ -32,15 +33,15 @@ class GetTimetablesAcquireController extends Controller
             //範囲外の場合
             if (strtotime($date) < $oldestDate || $latestDate <= strtotime($date)) {
                 //今日のものに変更
-                $date = date("Y-m-d", strtotime(today()));
+                $date = date("Y-m-d", strtotime($today));
 
                 //月曜日判定
-                $dateDayOfWeek = date("w", strtotime(today()));
+                $dateDayOfWeek = date("w", strtotime($date));
                 if ($dateDayOfWeek !== 1) {
                     $date = date('Y-m-d', strtotime(- ($dateDayOfWeek - 1) . " day", strtotime($date)));
                 }
                 //値取り直し
-                $yearAfterNext = date("Y", strtotime(today() . +2 . ' year'));
+                $yearAfterNext = date("Y", strtotime($date . +2 . ' year'));
                 $holidayDataYear = explode("-", ($date))[0];
                 $yearHolidayDatas = $this->getHolidays($holidayDataYear);
             }

--- a/frontend/assets/scss/timetable.scss
+++ b/frontend/assets/scss/timetable.scss
@@ -1,74 +1,77 @@
 //PC用scss
 @media screen and (min-width: 768px) {
-.timetable {
-  writing-mode: vertical-lr;
-  border-collapse: collapse;
-  table-layout: fixed;
-  width: 1200px;
-  height: 660px;
-  background-color: #ffffff;
-  box-shadow: 0 0 0 1px #333 inset;
-}
+  .timetable {
+    writing-mode: vertical-lr;
+    border-collapse: collapse;
+    table-layout: fixed;
+    width: 1200px;
+    height: 660px;
+    background-color: #ffffff;
+    box-shadow: 0 0 0 1px #333 inset;
+  }
 
-.register {
-  width: 1120px;
-  height: 580px;
-  margin-top: 20px;
-  margin-left: 24px;
-  position: fixed;
-  top: 220px;
-  left: 224px;
-}
-.horizontal-writing {
-  box-shadow: 0 0 0 1px #333 inset;
-  writing-mode: horizontal-tb;
-  word-break: break-word;
-}
+  .register {
+    width: 1120px;
+    height: 580px;
+    margin-top: 20px;
+    margin-left: 24px;
+    position: fixed;
+    top: 220px;
+    left: 224px;
+  }
+  .horizontal-writing {
+    box-shadow: 0 0 0 1px #333 inset;
+    writing-mode: horizontal-tb;
+    word-break: break-word;
+  }
 
-.vertical-head {
-  width: 80px;
-  height: 80px;
-}
-.dayOfWeek-head {
-  width: 80px;
-  height: 40px;
-}
-.lesson-cell {
-  text-align: center;
-  width: 160px;
-  height: 90px;
-  font-weight: bold;
-}
-/* 科目/教師*/
-.lesson-holiday-cell {
-  background-color: #f4c9c9;
-}
-.lesson-cell-box {
-  margin: 5px;
-}
-/* 日付 */
-.date-cell {
-  width: 160px;
-  height: 80px;
-  word-break: break-word;
-}
-.date-holiday-cell {
-  background-color: #f4c9c9;
-}
-/* 時限　*/
-.period-cell {
-  width: 80px;
-  height: 90px;
-}
-/* 曜日 */
-.dayOfWeek-cell {
-  word-break: break-word;
-  width: 160px;
-  height: 40px;
-  color: #ffffff;
-  background-color: #5160ae;
-}
-
+  .vertical-head {
+    width: 80px;
+    height: 80px;
+  }
+  .dayOfWeek-head {
+    width: 80px;
+    height: 40px;
+  }
+  .lesson-cell {
+    text-align: center;
+    width: 160px;
+    height: 90px;
+    font-weight: bold;
+  }
+  /* 範囲外 */
+  .unavailable-cell {
+    background-color: #a9a9a9;
+  }
+  /* 科目/教師*/
+  .lesson-holiday-cell {
+    background-color: #f4c9c9;
+  }
+  .lesson-cell-box {
+    margin: 5px;
+  }
+  /* 日付 */
+  .date-cell {
+    width: 160px;
+    height: 80px;
+    word-break: break-word;
+  }
+  .date-holiday-cell {
+    background-color: #f4c9c9;
+  }
+  /* 時限　*/
+  .period-cell {
+    width: 80px;
+    height: 90px;
+  }
+  /* 曜日 */
+  .dayOfWeek-cell {
+    word-break: break-word;
+    width: 160px;
+    height: 40px;
+    color: #ffffff;
+    background-color: #5160ae;
+  }
 }
 
 //モバイル用scss

--- a/frontend/components/timetable-component.vue
+++ b/frontend/components/timetable-component.vue
@@ -15,6 +15,7 @@
         <!--日付、曜日表示-->
         <TimetableDate
           :is-holiday="timetable.isHoliday"
+          :is-unavailable="timetable.isunavailable"
           :date="dateFormat(timetable.date)"
           :holiday-title="timetable.holidayTitle"
           :day-of-week="timetable.dayOfWeek"
@@ -26,7 +27,10 @@
           <!--祝日処理-->
           <!--6回ループさせる-->
           <template v-for="holidayCell of blankCell" :key="holidayCell">
-            <TimetableLesson :is-holiday="timetable.isHoliday"></TimetableLesson>
+            <TimetableLesson
+              :is-holiday="timetable.isHoliday"
+              :is-unavailable="timetable.isunavailable"
+            ></TimetableLesson>
           </template>
         </template>
         <template v-else>
@@ -35,7 +39,12 @@
           <template v-if="timetable.dayOfWeek === 0">
             <!--日曜の処理-->
             <template v-for="lessons in timetable.lessons" :key="lessons">
-              <TimetableLesson :is-holiday="true" :subject="lessons.subject" :teacher-name="lessons.teacher">
+              <TimetableLesson
+                :is-holiday="true"
+                :is-unavailable="timetable.isunavailable"
+                :subject="lessons.subject"
+                :teacher-name="lessons.teacher"
+              >
               </TimetableLesson>
             </template>
           </template>
@@ -45,6 +54,7 @@
             <template v-for="lessons in timetable.lessons" :key="lessons">
               <TimetableLesson
                 :is-holiday="timetable.isHoliday"
+                :is-unavailable="timetable.isunavailable"
                 :subject="lessons.subject"
                 :teacher-name="lessons.teacher"
               >
@@ -70,6 +80,7 @@ const props = defineProps({
         date: '',
         dayOfWeek: 0,
         isHoliday: false,
+        isunavailable: true,
         lessons: () => [],
         holidayTitle: '',
       },

--- a/frontend/components/timetable-date.vue
+++ b/frontend/components/timetable-date.vue
@@ -3,10 +3,7 @@
   <!--祝日判断-->
   <template v-if="props.isHoliday">
     <!--祝日-->
-    <th
-      class="horizontal-writing date-cell"
-      :class="[isUnavailable === true ? 'unavailable-cell' : 'date-holiday-cell']"
-    >
+    <th class="horizontal-writing date-cell" :class="[isUnavailable ? 'unavailable-cell' : 'date-holiday-cell']">
       <p class="font-size-l">{{ props.date }}</p>
       <p :class="[fontSizeHolidayTitle()]">{{ props.holidayTitle }}</p>
     </th>
@@ -14,10 +11,7 @@
   <template v-else>
     <!--日曜判断-->
     <template v-if="props.dayOfWeek === 0">
-      <th
-        class="horizontal-writing date-cell"
-        :class="[isUnavailable === true ? 'unavailable-cell' : 'date-holiday-cell']"
-      >
+      <th class="horizontal-writing date-cell" :class="[isUnavailable ? 'unavailable-cell' : 'date-holiday-cell']">
         <p class="font-size-l">{{ props.date }}</p>
       </th>
     </template>

--- a/frontend/components/timetable-date.vue
+++ b/frontend/components/timetable-date.vue
@@ -3,7 +3,10 @@
   <!--祝日判断-->
   <template v-if="props.isHoliday">
     <!--祝日-->
-    <th class="horizontal-writing date-holiday-cell">
+    <th
+      class="horizontal-writing date-cell"
+      :class="[isUnavailable === true ? 'unavailable-cell' : 'date-holiday-cell']"
+    >
       <p class="font-size-l">{{ props.date }}</p>
       <p :class="[fontSizeHolidayTitle()]">{{ props.holidayTitle }}</p>
     </th>
@@ -11,13 +14,16 @@
   <template v-else>
     <!--日曜判断-->
     <template v-if="props.dayOfWeek === 0">
-      <th class="horizontal-writing date-holiday-cell">
+      <th
+        class="horizontal-writing date-cell"
+        :class="[isUnavailable === true ? 'unavailable-cell' : 'date-holiday-cell']"
+      >
         <p class="font-size-l">{{ props.date }}</p>
       </th>
     </template>
     <!--日曜以外-->
     <template v-else>
-      <th class="horizontal-writing date-cell">
+      <th class="horizontal-writing date-cell" :class="{ 'unavailable-cell': isUnavailable }">
         <p class="font-size-l">{{ props.date }}</p>
       </th>
     </template>
@@ -26,6 +32,10 @@
 <script lang="ts" setup>
 const props = defineProps({
   isHoliday: {
+    type: Boolean,
+    required: true,
+  },
+  isUnavailable: {
     type: Boolean,
     required: true,
   },

--- a/frontend/components/timetable-lesson.vue
+++ b/frontend/components/timetable-lesson.vue
@@ -1,5 +1,8 @@
 <template>
-  <td class="lesson-cell horizontal-writing" :class="{ 'lesson-holiday-cell': isHoliday }">
+  <td
+    class="lesson-cell horizontal-writing"
+    :class="[isUnavailable ? 'unavailable-cell' : isHoliday ? 'date-holiday-cell' : '']"
+  >
     <div>
       <p class="lesson-cell-box" :class="[fontSizeClass('subject')]">{{ props.subject }}</p>
       <p class="lesson-cell-box" :class="[fontSizeClass('teacher')]">{{ props.teacherName }}</p>
@@ -19,6 +22,10 @@ const props = defineProps({
   },
   isHoliday: {
     type: Boolean,
+  },
+  isUnavailable: {
+    type: Boolean,
+    required: true,
   },
 })
 /* 科目名／教師名の文字の大きさを決める */

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -133,12 +133,15 @@ async function getTimetableData() {
       baseURL: config.public.apiUrl,
       query: { date: view.value },
     })
+    if (response.value == null) {
+      return
+    }
     //クエリの日付と渡されている日付が同じか確認
-    if (response.value?.[0].date !== view.value) {
+    if (response.value[0].date !== view.value) {
       navigateTo({
         path: '/home',
         query: {
-          date: response.value?.[0].date,
+          date: response.value[0].date,
         },
       })
     }

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -200,7 +200,7 @@ const timetables2: Timetable[] = [
 const view = ref()
 const loadingDisplay = ref(false)
 let displayDate: Date
-const oldestDate = parse('20150104', 'yyyyMMdd', new Date())
+const oldestDate = parse('20150101', 'yyyyMMdd', new Date())
 const nextYear = String(new Date().getFullYear() + 1)
 const latestString = nextYear + '1225'
 const latestDate = parse(latestString, 'yyyyMMdd', new Date())
@@ -279,7 +279,15 @@ async function getTimetableData() {
       baseURL: config.public.apiUrl,
       query: { date: view.value },
     })
-
+    //クエリの日付と渡されている日付が同じか確認
+    if (response.value?.[0].date !== view.value) {
+      navigateTo({
+        path: '/home',
+        query: {
+          date: response.value?.[0].date,
+        },
+      })
+    }
     if (response.value != null) {
       timetables.value = response.value
     }
@@ -352,7 +360,7 @@ function getMonday(date: Date) {
 watch(
   () => route.query,
   () => {
-    location.reload()
+    getTimetableData()
   }
 )
 </script>

--- a/frontend/pages/studentHome.vue
+++ b/frontend/pages/studentHome.vue
@@ -151,7 +151,7 @@ async function getTimetableData() {
     //クエリの日付と渡されている日付が同じか確認
     if (response.value?.[0].date !== view.value) {
       navigateTo({
-        path: '/home',
+        path: '/studentHome',
         query: {
           date: response.value?.[0].date,
         },

--- a/frontend/pages/studentHome.vue
+++ b/frontend/pages/studentHome.vue
@@ -4,23 +4,31 @@
       <!-- html記述場所 -->
       <!--ボタン-->
       <div class="button-wrapper">
-            <button class="font-size-xs button-wrapper__button" @click="getThisWeekTimetables">今週の時間割</button>
-            <button class="font-size-xs button-wrapper__button" @click="openCarendar">日付選択</button>
-            <calendar-modal :is-shown="isShown" @update:value="selectDate"> </calendar-modal>
+        <button class="font-size-xs button-wrapper__button" @click="getThisWeekTimetables">今週の時間割</button>
+        <button class="font-size-xs button-wrapper__button" @click="openCarendar">日付選択</button>
+        <calendar-modal :is-shown="isShown" @update:value="selectDate"> </calendar-modal>
       </div>
-        <!--三角ボタン-->
-        <div class="triangle-wrapper">
-          <div class="triangle-wrapper__inner">
-            <!--先週-->
-            <button class="triangle-wrapper__inner__left" :disabled="displayLeftButton()" @click="getLastWeekTimetable()"></button>
-            <!--来週-->
-            <button class="triangle-wrapper__inner__right" :disabled="displayRightButton()" @click="getNextWeekTimetable()"></button>
-          </div>
+      <!--三角ボタン-->
+      <div class="triangle-wrapper">
+        <div class="triangle-wrapper__inner">
+          <!--先週-->
+          <button
+            class="triangle-wrapper__inner__left"
+            :disabled="displayLeftButton()"
+            @click="getLastWeekTimetable()"
+          ></button>
+          <!--来週-->
+          <button
+            class="triangle-wrapper__inner__right"
+            :disabled="displayRightButton()"
+            @click="getNextWeekTimetable()"
+          ></button>
         </div>
-        <!--時間割-->
-        <div v-show="loadingDisplay" class="table-wrapper">
-          <TimetableComponent :timetables="timetables"></TimetableComponent>
-        </div>
+      </div>
+      <!--時間割-->
+      <div v-show="loadingDisplay" class="table-wrapper">
+        <TimetableComponent :timetables="timetables"></TimetableComponent>
+      </div>
     </section>
   </default-layout>
 </template>
@@ -37,7 +45,7 @@ const view = ref()
 const calendarView = view
 const loadingDisplay = ref(false)
 let displayDate: Date
-const oldestDate = parse('20150104', 'yyyyMMdd', new Date())
+const oldestDate = parse('20150101', 'yyyyMMdd', new Date())
 const nextYear = String(new Date().getFullYear() + 1)
 const latestString = nextYear + '1225'
 const latestDate = parse(latestString, 'yyyyMMdd', new Date())
@@ -140,7 +148,15 @@ async function getTimetableData() {
       baseURL: config.public.apiUrl,
       query: { date: view.value },
     })
-
+    //クエリの日付と渡されている日付が同じか確認
+    if (response.value?.[0].date !== view.value) {
+      navigateTo({
+        path: '/home',
+        query: {
+          date: response.value?.[0].date,
+        },
+      })
+    }
     if (response.value != null) {
       timetables.value = response.value
     }
@@ -185,7 +201,7 @@ watch(
   margin: 0 auto;
 }
 // 時間割テーブル
-.table-wrapper{
+.table-wrapper {
   overflow-x: auto;
   margin-top: 16px;
 }

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -35,12 +35,13 @@
                     :is-holiday="false"
                     :subject="getSubject(period, dayOfWeek)"
                     :teacher-name="getTeacher(period, dayOfWeek)"
+                    :is-unavailable="false"
                   />
                 </template>
 
                 <template v-else>
                   <!--データがないとき-->
-                  <TimetableLesson :is-holiday="false" />
+                  <TimetableLesson :is-holiday="false" :is-unavailable="false" />
                 </template>
               </template>
             </tr>

--- a/frontend/types/response/timetablesAcquireResponse.ts
+++ b/frontend/types/response/timetablesAcquireResponse.ts
@@ -2,6 +2,7 @@ export interface Timetable {
   date: string
   dayOfWeek: number
   isHoliday: boolean
+  isunavailable: boolean
   lessons?: Array<Lesson>
   holidayTitle?: string
 }


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-62

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
・範囲外かどうかをResponseに持たせる
・渡された日付が2014年以前や再来年以降の場合におこなう処理を記述

<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/c4831683-9595-4579-a41b-d5b8c0c44673)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
