### PR TITLE
認証部分に処理の追加

### DIFF
--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -7,7 +7,7 @@
 //   middleware: 'auth'
 // })
 // </script>
-export default defineNuxtRouteMiddleware(async () => {
+export default defineNuxtRouteMiddleware(async (to, from) => {
   const config = useRuntimeConfig()
   const route = useRouter()
 
@@ -15,11 +15,24 @@ export default defineNuxtRouteMiddleware(async () => {
     baseURL: config.public.apiUrl,
     credentials: 'include',
   })
+
+  // ログイン画面にアクセスした時の処理
+  if(to.path === `/teachersLogin`){
+    if(status.value === 'success'){
+      // ログイン済み：一覧画面にリダイレクト
+      return route.push('/home')
+    } else {
+      // 未ログイン：画面を表示
+      return
+    }
+  }
+
+  // その他の画面にアクセスした時の処理
   if(status.value === 'success'){
-    // トークンが正しい場合にページの表示
+    // ログイン済みの場合：画面を表示
     return
   } else {
-    // トークンが正しくない場合はログイン画面にリダイレクト
+    // 未ログイン：ログイン画面にリダイレクト
     return route.push('/teachersLogin')
   }
 });

--- a/frontend/pages/teachersLogin.vue
+++ b/frontend/pages/teachersLogin.vue
@@ -57,6 +57,9 @@
 </template>
 
 <script lang="ts" setup>
+definePageMeta({
+  middleware: 'auth'
+})
 import { messagesResponse } from '~~/types/response/messagesResponse'
 // パスワード表示切り替え部分
 const isChecked = ref(false)


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-65

# 変更内容

・ログイン画面に認証処理の追加
・ログイン画面にアクセスした際にログイン済みの場合は一覧画面にリダイレクトするように変更

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
