### PR TITLE
バグ_ 一覧画面No.28の修正

### DIFF
--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -20,7 +20,9 @@
           <button class="button-font-color usual-button font-size-l" @click="openCalendarModal">日付選択</button>
           <button class="button-font-color usual-button font-size-l" @click="goToRegisterPage">時間割登録</button>
           <button class="button-font-color usual-button font-size-m" @click="goToStudentPage">生徒用画面確認</button>
-          <button class="button-font-color usual-button font-size-l" @click="commonLogout">ログアウト</button>
+          <button class="button-font-color usual-button font-size-l" type="button" @click="commonLogout">
+            ログアウト
+          </button>
         </div>
         <calendar-modal :is-shown="isShown" @update:value="selectDate" />
 

--- a/frontend/util/logout.ts
+++ b/frontend/util/logout.ts
@@ -1,7 +1,7 @@
-export function commonLogout() {
+export async function commonLogout() {
   const router = useRouter()
   const config = useRuntimeConfig()
-  useFetch('/api/logout', {
+  await useFetch('/api/logout', {
     baseURL: config.public.apiUrl,
     credentials: 'include',
   })


### PR DESCRIPTION
# 関連 Issue
https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/issues/35

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-71

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

・commonLogoutの記述変更
・一覧画面のボタンにtype="button"を追加

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
