### PR TITLE
時間割登録APIの機能修正

### DIFF
--- a/backend/app/Http/Requests/RegisterPostRequest.php
+++ b/backend/app/Http/Requests/RegisterPostRequest.php
@@ -30,14 +30,16 @@ class RegisterPostRequest extends FormRequest
      */
     public function rules()
     {
+        $today = today();
+        $latestDate = date("Y", strtotime("1  year")) . '-12-31';
         return [
-            'time.start' => 'required|date_format:"Y-m-d"',
-            'time.end' => 'required|date_format:"Y-m-d"',
+            'time.start' => 'required|date_format:"Y-m-d"|after:2014-01-01|before:' . $latestDate,
+            'time.end' => 'required|date_format:"Y-m-d"|after:time.start|before:' . $latestDate,
             'lessons' => 'required|array',
             'lessons.*.subject' => 'required_with:lessons.*.subject|string|max:10',
             'lessons.*.teacher' => 'required_with:lessons.*.teacher|string|max:10',
-            'lessons.*.dayOfWeek' => 'required_with:lessons.*.dayOfWeek|numeric|min:0|max:6',
-            'lessons.*.period' => 'required_with:lessons.*.period|numeric|min:1|max:6'
+            'lessons.*.dayOfWeek' => 'required_with:lessons.*.dayOfWeek|integer|min:0|max:6',
+            'lessons.*.period' => 'required_with:lessons.*.period|integer|min:1|max:6'
         ];
     }
 

--- a/backend/app/Http/Requests/RegisterPostRequest.php
+++ b/backend/app/Http/Requests/RegisterPostRequest.php
@@ -30,7 +30,6 @@ class RegisterPostRequest extends FormRequest
      */
     public function rules()
     {
-        $today = today();
         $latestDate = date("Y", strtotime("1  year")) . '-12-31';
         return [
             'time.start' => 'required|date_format:"Y-m-d"|after:2014-01-01|before:' . $latestDate,

--- a/backend/app/Http/Requests/RegisterPostRequest.php
+++ b/backend/app/Http/Requests/RegisterPostRequest.php
@@ -32,8 +32,8 @@ class RegisterPostRequest extends FormRequest
     {
         $latestDate = date("Y", strtotime("1  year")) . '-12-31';
         return [
-            'time.start' => 'required|date_format:"Y-m-d"|after:2014-01-01|before:' . $latestDate,
-            'time.end' => 'required|date_format:"Y-m-d"|after:time.start|before:' . $latestDate,
+            'time.start' => 'required|date_format:"Y-m-d"|after_or_equal::2014-01-01|before_or_equal:' . $latestDate,
+            'time.end' => 'required|date_format:"Y-m-d"|after_or_equal:time.start|before_or_equal:' . $latestDate,
             'lessons' => 'required|array',
             'lessons.*.subject' => 'required_with:lessons.*.subject|string|max:10',
             'lessons.*.teacher' => 'required_with:lessons.*.teacher|string|max:10',

--- a/backend/app/Http/Requests/RegisterPostRequest.php
+++ b/backend/app/Http/Requests/RegisterPostRequest.php
@@ -32,7 +32,7 @@ class RegisterPostRequest extends FormRequest
     {
         $latestDate = date("Y", strtotime("1  year")) . '-12-31';
         return [
-            'time.start' => 'required|date_format:"Y-m-d"|after_or_equal::2014-01-01|before_or_equal:' . $latestDate,
+            'time.start' => 'required|date_format:"Y-m-d"|after_or_equal:2014-01-01|before_or_equal:' . $latestDate,
             'time.end' => 'required|date_format:"Y-m-d"|after_or_equal:time.start|before_or_equal:' . $latestDate,
             'lessons' => 'required|array',
             'lessons.*.subject' => 'required_with:lessons.*.subject|string|max:10',


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-80

# 変更内容

-開始日、終了日、曜日、時限のバリデーションを修正
<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
