### PR TITLE
バグ修正_登録画面No.9

### DIFF
--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -24,7 +24,7 @@
             ログアウト
           </button>
         </div>
-        <calendar-modal :is-shown="isShown" @update:value="selectDate" />
+        <calendar-modal :is-shown="isShown" @update:value="selectDate" @on-close="() => (isShown = false)" />
 
         <!--時間割-->
         <div>

--- a/frontend/pages/studentHome.vue
+++ b/frontend/pages/studentHome.vue
@@ -6,7 +6,8 @@
       <div class="button-wrapper">
         <button class="font-size-xs button-wrapper__button" @click="getThisWeekTimetables">今週の時間割</button>
         <button class="font-size-xs button-wrapper__button" @click="openCarendar">日付選択</button>
-        <calendar-modal :is-shown="isShown" @update:value="selectDate"> </calendar-modal>
+        <calendar-modal :is-shown="isShown" @update:value="selectDate" @on-close="() => (isShown = false)">
+        </calendar-modal>
       </div>
       <!--三角ボタン-->
       <div class="triangle-wrapper">

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -5,7 +5,13 @@
         <div class="font-size-m">開始日終了日選択</div>
       </button>
       <label class="datetext">{{ start }}~{{ end }}</label>
-      <calendar-modal :is-shown="isShown" @update:value="selectDate" selection-type="range"> </calendar-modal>
+      <calendar-modal
+        :is-shown="isShown"
+        @update:value="selectDate"
+        selection-type="range"
+        @on-close="() => (isShown = false)"
+      >
+      </calendar-modal>
     </div>
 
     <p>


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->
・backlog
https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-72

・issues
https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/issues/39

# 変更内容
- 各画面でカレンダーモーダルが閉じることができないバグを修正
<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
