### PR TITLE
バグ修正_登録画面試験外項目

### DIFF
--- a/frontend/components/timetable-lesson-register.vue
+++ b/frontend/components/timetable-lesson-register.vue
@@ -29,12 +29,13 @@ const isShown = ref(false)
 
 function onclick() {
   isShown.value = !isShown.value
-  console.log('onclick')
 }
 
 function deleteClass() {
   updateSubject.value = ''
   updateTeacher.value = ''
+  emit('update:subject', updateSubject.value)
+  emit('update:teacherName', updateTeacher.value)
 }
 
 const props = defineProps({


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->
・backlog
https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-72

・issues
https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/issues/38

# 変更内容
- 時間割削除ボタンが画面上でしか削除されていないバグを修正
- 不要行削除
<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
