### PR TITLE
subject-teacher-register-modal.vueの文法エラーを除去

### DIFF
--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -35,7 +35,7 @@
             </div>
           </div>
 
-          <button type="button" class="usual-button cancel-button" @click.stop="isShown = false">
+          <button type="button" class="usual-button cancel-button" @click.stop="onClose">
             <div class="font-size-l">キャンセル</div>
           </button>
           <button type="button" class="unusual-button register-button" @click="regist">


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->
・backlog
https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-72
・issue
https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/issues/59
# 変更内容
- subject-teacher-register-modal.vueの文法エラーを除去
<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
