### PR TITLE
教師認証API試験外項目の修正

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -12,7 +12,7 @@ class AuthController extends Controller
     public function __invoke(Request $request)
     {
         // Cookieの取得
-        $cookieValue = Cookie::get('api_token', 'default');
+        $cookieValue = Cookie::get('api_token');
         // Teacherテーブルのトークン取得
         $user = Teacher::where('api_token', $cookieValue)->first();
         $response = "";

--- a/backend/database/migrations/2023_05_18_070219_alter2_teachers_table.php
+++ b/backend/database/migrations/2023_05_18_070219_alter2_teachers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('teachers', function (Blueprint $table) {
+            $table->unique('email')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('teachers', function (Blueprint $table) {
+            $table->string('email')->change();
+        });
+    }
+};


### PR DESCRIPTION
# 関連 Issue

#63 

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-88

# 変更内容

authControllerのデフォルトで設定する値の編集
teacherテーブルのemailをuniqueに変更

merge後に各自migrationを行ってほしいです
`sail artisan migrate`
DBに同じemailが登録されている場合は削除が必要になります

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
