### PR TITLE
日付選択のバグ修正

### DIFF
--- a/backend/app/Http/Requests/RegisterPostRequest.php
+++ b/backend/app/Http/Requests/RegisterPostRequest.php
@@ -32,7 +32,7 @@ class RegisterPostRequest extends FormRequest
     {
         $latestDate = date("Y", strtotime("1  year")) . '-12-31';
         return [
-            'time.start' => 'required|date_format:"Y-m-d"|after_or_equal:2014-01-01|before_or_equal:' . $latestDate,
+            'time.start' => 'required|date_format:"Y-m-d"|after_or_equal:2015-01-01|before_or_equal:' . $latestDate,
             'time.end' => 'required|date_format:"Y-m-d"|after_or_equal:time.start|before_or_equal:' . $latestDate,
             'lessons' => 'required|array',
             'lessons.*.subject' => 'required_with:lessons|string|max:10',

--- a/frontend/components/calendar-modal.vue
+++ b/frontend/components/calendar-modal.vue
@@ -27,7 +27,7 @@ import { getYear } from 'date-fns'
 
 const date = ref()
 
-const minDate = computed(() => new Date(2015, 0, 5))
+const minDate = computed(() => new Date(2014, 11, 29))
 const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 31))
 
 const props = defineProps({

--- a/frontend/components/calendar-modal.vue
+++ b/frontend/components/calendar-modal.vue
@@ -26,8 +26,7 @@ import { ref } from 'vue'
 import { getYear } from 'date-fns'
 
 const date = ref()
-let minDate = computed(() => new Date(2014, 11, 29))
-const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 31))
+
 const props = defineProps({
   isShown: false,
   selectionType: {
@@ -36,10 +35,14 @@ const props = defineProps({
     validator: (value) => ['week-picker', 'range'].includes(value),
   },
 })
-
-if (props.selectionType === 'range') {
-  minDate = computed(() => new Date(2015, 0, 1))
-}
+const minDate = computed(() => {
+  if (props.selectionType === 'range') {
+    return new Date(2015, 0, 1)
+  } else {
+    return new Date(2014, 11, 29)
+  }
+})
+const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 31))
 
 const emit = defineEmits()
 

--- a/frontend/components/calendar-modal.vue
+++ b/frontend/components/calendar-modal.vue
@@ -26,10 +26,8 @@ import { ref } from 'vue'
 import { getYear } from 'date-fns'
 
 const date = ref()
-
-const minDate = computed(() => new Date(2014, 11, 29))
+let minDate = computed(() => new Date(2014, 11, 29))
 const maxDate = computed(() => new Date(getYear(new Date()) + 1, 11, 31))
-
 const props = defineProps({
   isShown: false,
   selectionType: {
@@ -38,6 +36,11 @@ const props = defineProps({
     validator: (value) => ['week-picker', 'range'].includes(value),
   },
 })
+console.log(props.selectionType)
+
+if (props.selectionType === 'range') {
+  minDate = computed(() => new Date(2015, 0, 1))
+}
 
 const emit = defineEmits()
 

--- a/frontend/components/calendar-modal.vue
+++ b/frontend/components/calendar-modal.vue
@@ -36,7 +36,6 @@ const props = defineProps({
     validator: (value) => ['week-picker', 'range'].includes(value),
   },
 })
-console.log(props.selectionType)
 
 if (props.selectionType === 'range') {
   minDate = computed(() => new Date(2015, 0, 1))


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->
・backlog
https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-98
・issue
https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/issues/84
# 変更内容
・日付選択のカレンダーモーダルで、2015-01-01が含まれる週を選択できるように変更
　　weekpickerとrangeでminDateを変更するように

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
