### PR TITLE
TimetableSeeder修正

### DIFF
--- a/backend/database/seeders/TimetableSeeder.php
+++ b/backend/database/seeders/TimetableSeeder.php
@@ -18,43 +18,409 @@ class TimetableSeeder extends Seeder
     public function run()
     {
         //
-        for ($dayOfWeekCount = 0; $dayOfWeekCount < 7; $dayOfWeekCount++) {
-            for ($periodCount = 1; $periodCount < 7; $periodCount++) {
-                DB::table('timetables')->insert(
-                    [
-                        'day_of_week' => $dayOfWeekCount,
-                        'period' => $periodCount,
-                        'subject' => '国語',
-                        'teacher_name' => '内藤',
-                        'start_date' => '2023-04-01',
-                        'end_date' => '2023-08-31',
-                        'created_at' => '2023-01-01',
-                    ],
-                );
-                DB::table('timetables')->insert(
-                    [
-                        'day_of_week' => $dayOfWeekCount,
-                        'period' => $periodCount,
-                        'subject' => '英語',
-                        'teacher_name' => '佐々木',
-                        'start_date' => '2023-04-01',
-                        'end_date' => '2023-04-16',
-                        'created_at' => '2023-03-31',
-                    ],
-                );
 
-                DB::table('timetables')->insert(
-                    [
-                        'day_of_week' => $dayOfWeekCount,
-                        'period' => $periodCount,
-                        'subject' => '数学',
-                        'teacher_name' => '鈴木',
-                        'start_date' => '2023-04-04',
-                        'end_date' => '2023-04-10',
-                        'created_at' => '2023-04-03',
-                    ],
-                );
-            }
-        }
+        //月曜日
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 1,
+                'period' => 1,
+                'subject' => '社会',
+                'teacher_name' => '井村',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 1,
+                'period' => 2,
+                'subject' => '体育',
+                'teacher_name' => '川崎',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 1,
+                'period' => 3,
+                'subject' => '国語 ',
+                'teacher_name' => '内藤',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 1,
+                'period' => 4,
+                'subject' => '数学',
+                'teacher_name' => '佐々木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 1,
+                'period' => 5,
+                'subject' => '英語',
+                'teacher_name' => 'Michael',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 1,
+                'period' => 6,
+                'subject' => '総合',
+                'teacher_name' => '芦屋',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        //火曜日
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 1,
+                'subject' => '社会',
+                'teacher_name' => '井村',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 2,
+                'subject' => '英語',
+                'teacher_name' => 'Michael',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 3,
+                'subject' => '数学',
+                'teacher_name' => '佐々木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 4,
+                'subject' => '技術',
+                'teacher_name' => '立花',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 5,
+                'subject' => '理科',
+                'teacher_name' => '青木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 6,
+                'subject' => '国語',
+                'teacher_name' => '内藤',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        //水曜日
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 1,
+                'subject' => '理科',
+                'teacher_name' => '青木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 2,
+                'subject' => '家庭科',
+                'teacher_name' => '山口',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 3,
+                'subject' => '英語',
+                'teacher_name' => 'Michael',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 4,
+                'subject' => '美術',
+                'teacher_name' => '沢田',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 5,
+                'subject' => '体育',
+                'teacher_name' => '川崎',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 6,
+                'subject' => '数学',
+                'teacher_name' => '佐々木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        //木曜日
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 4,
+                'period' => 1,
+                'subject' => '数学',
+                'teacher_name' => '佐々木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 4,
+                'period' => 2,
+                'subject' => '理科',
+                'teacher_name' => '青木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 4,
+                'period' => 3,
+                'subject' => '英語',
+                'teacher_name' => 'Michael',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 4,
+                'period' => 4,
+                'subject' => '社会',
+                'teacher_name' => '井村',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 4,
+                'period' => 5,
+                'subject' => '体育',
+                'teacher_name' => '川崎',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 4,
+                'period' => 6,
+                'subject' => '国語',
+                'teacher_name' => '内藤',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        //金曜日
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 5,
+                'period' => 1,
+                'subject' => '英語',
+                'teacher_name' => 'Michael',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 5,
+                'period' => 2,
+                'subject' => '数学',
+                'teacher_name' => '佐々木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 5,
+                'period' => 3,
+                'subject' => '国語',
+                'teacher_name' => '内藤',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 5,
+                'period' => 4,
+                'subject' => '理科',
+                'teacher_name' => '青木',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 5,
+                'period' => 5,
+                'subject' => '音楽',
+                'teacher_name' => '岩崎',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 5,
+                'period' => 6,
+                'subject' => '道徳',
+                'teacher_name' => '芦屋',
+                'start_date' => '2023-04-01',
+                'end_date' => '2023-08-31',
+                'created_at' => '2023-01-01',
+            ]
+        );
+
+        //臨時など
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 1,
+                'subject' => '体育祭練習',
+                'teacher_name' => '芦屋',
+                'start_date' => '2023-06-01',
+                'end_date' => '2023-06-30',
+                'created_at' => '2023-05-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 2,
+                'subject' => '体育祭練習',
+                'teacher_name' => '芦屋',
+                'start_date' => '2023-06-01',
+                'end_date' => '2023-06-30',
+                'created_at' => '2023-05-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 3,
+                'subject' => '体育祭練習',
+                'teacher_name' => '芦屋',
+                'start_date' => '2023-06-01',
+                'end_date' => '2023-06-30',
+                'created_at' => '2023-05-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 2,
+                'period' => 4,
+                'subject' => '体育祭練習',
+                'teacher_name' => '芦屋',
+                'start_date' => '2023-06-01',
+                'end_date' => '2023-06-30',
+                'created_at' => '2023-05-01',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 1,
+                'subject' => '講演会',
+                'teacher_name' => '外部講師',
+                'start_date' => '2023-05-31',
+                'end_date' => '2023-05-31',
+                'created_at' => '2023-04-14',
+            ]
+        );
+        DB::table('timetables')->insert(
+            [
+                'day_of_week' => 3,
+                'period' => 2,
+                'subject' => '講演会',
+                'teacher_name' => '外部講師',
+                'start_date' => '2023-05-31',
+                'end_date' => '2023-05-31',
+                'created_at' => '2023-04-14',
+            ]
+        );
     }
 }


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-97

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

・TimeTableSeederを修正し、初期データを更新
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/2475fc03-4e3a-4160-b963-5365a56e5350)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
