### PR TITLE
登録画面、更新画面で時限を表示

### DIFF
--- a/frontend/components/timetable-component-register.vue
+++ b/frontend/components/timetable-component-register.vue
@@ -2,6 +2,13 @@
   <table class="timetable register">
     <tbody>
       <!--最初の列 空白と時間割の時限を置く-->
+      <tr>
+        <th class="dayOfWeek-head horizontal-writing"></th>
+        <!--時限表示ループ-->
+        <template v-for="periodNumber of blankCell" :key="periodNumber">
+          <TimetablePeriod :period="periodNumber"></TimetablePeriod>
+        </template>
+      </tr>
       <!--配列をループ-->
       <template v-for="timetable in props.timetables" :key="timetable">
         <tr>
@@ -53,6 +60,8 @@ for (const timetable of props.timetables) {
     )
   }
 }
+/* 6回回す用　*/
+const blankCell = 6
 
 /* 曜日の文字を返却 */
 function dayOfWeekChangeString(dayOfWeek: number) {

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -23,6 +23,14 @@
       <div class="right-area">
         <table class="timetable-update">
           <!--時間割-->
+          <!--最初の列 空白と時間割の時限を置く-->
+          <tr>
+            <th class="dayOfWeek-head horizontal-writing"></th>
+            <!--時限表示ループ-->
+            <template v-for="periodNumber of blankCell" :key="periodNumber">
+              <TimetablePeriod :period="periodNumber"></TimetablePeriod>
+            </template>
+          </tr>
           <template v-for="dayOfWeek in dayOfWeekCount" :key="dayOfWeek">
             <tr>
               <TimetableDayOfWeek
@@ -79,6 +87,8 @@ import { commonLogout } from '~~/util/logout'
 definePageMeta({
   middleware: 'auth',
 })
+/* 6回回す用　*/
+const blankCell = 6
 
 /* 固定の変数　*/
 const periodCount: number = 6

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -27,7 +27,7 @@
           <tr>
             <th class="dayOfWeek-head horizontal-writing"></th>
             <!--時限表示ループ-->
-            <template v-for="periodNumber of blankCell" :key="periodNumber">
+            <template v-for="periodNumber of periodCount" :key="periodNumber">
               <TimetablePeriod :period="periodNumber"></TimetablePeriod>
             </template>
           </tr>
@@ -87,8 +87,6 @@ import { commonLogout } from '~~/util/logout'
 definePageMeta({
   middleware: 'auth',
 })
-/* 6回回す用　*/
-const blankCell = 6
 
 /* 固定の変数　*/
 const periodCount: number = 6


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-99

# 変更内容
- 登録画面に時限を追加
- 更新画面に時限を追加

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
・登録画面
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024649/47f79421-0c42-4058-bab5-81da86946393)
・更新画面
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024649/8e6a83bc-7786-4c71-90ec-2d368d9ab793)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
