### PR TITLE
更新画面_曜日表示修正

### DIFF
--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -25,9 +25,7 @@
           <!--時間割-->
           <template v-for="dayOfWeek in dayOfWeekCount" :key="dayOfWeek">
             <tr>
-              <TimetableDayOfWeek
-                :day-of-week="dayOfWeekChangeString(dayOfWeekNumber[dayOfWeek - 1])"
-              ></TimetableDayOfWeek>
+              <TimetableDayOfWeek :day-of-week="dayOfWeekChangeString(dayOfWeek)" />
               <template v-for="period in periodCount" :key="period">
                 <template v-if="lessonExist(period, dayOfWeek)">
                   <!--データがある時-->
@@ -73,7 +71,6 @@
 <script lang="ts" setup>
 import { useTimetables } from '~~/composables/useTimetables'
 import { messagesResponse } from '~~/types/response/messagesResponse'
-import { DAY_OF_WEEK } from '~~/util/constants'
 import { commonLogout } from '~~/util/logout'
 
 definePageMeta({
@@ -107,9 +104,6 @@ const timetablesData = {
   lessons: lessons.value,
 }
 
-//曜日用
-const dayOfWeekNumber = Object.values(DAY_OF_WEEK)
-
 //ホーム画面遷移
 function goToHome() {
   navigateTo({ path: '/home' })
@@ -123,7 +117,6 @@ function goToStudentPage() {
 async function registerTimetables() {
   //登録処理
   try {
-    console.log(timetablesData)
     const response = await $fetch<messagesResponse>('/api/timetablesCreate/', {
       method: 'POST',
       body: timetablesData,


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-103

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
・曜日表示を修正し、日曜を表示
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/d936424c-8141-4c35-b157-1014f7b2999f)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
