### PR TITLE
ログイン画面_生徒用画面遷移ボタン追加

### DIFF
--- a/frontend/pages/teachersLogin.vue
+++ b/frontend/pages/teachersLogin.vue
@@ -1,5 +1,8 @@
 <template>
   <default-layout page-name="ログイン画面">
+    <div class="button-area">
+      <button class="button-font-color usual-button font-size-m" @click="goToStudentPage">生徒用画面確認</button>
+    </div>
     <div class="container board-color">
       <section class="login">
         <div class="inner-title">
@@ -58,9 +61,15 @@
 
 <script lang="ts" setup>
 definePageMeta({
-  middleware: 'auth'
+  middleware: 'auth',
 })
 import { messagesResponse } from '~~/types/response/messagesResponse'
+
+//生徒用画面遷移
+function goToStudentPage() {
+  window.open('/studentHome', '_blank', 'noreferrer')
+}
+
 // パスワード表示切り替え部分
 const isChecked = ref(false)
 const passwordType = computed(function () {
@@ -185,5 +194,11 @@ const onClick = async () => {
 }
 .nonebox {
   background-color: #ffffff;
+}
+
+//生徒用画面ボタンエリア
+.button-area {
+  text-align: right;
+  margin-right: min(5%, 20px);
 }
 </style>

--- a/frontend/pages/teachersLogin.vue
+++ b/frontend/pages/teachersLogin.vue
@@ -136,7 +136,9 @@ const onClick = async () => {
 .container {
   width: 450px;
   height: 600px;
-  margin: 64px auto 0;
+  // margin: 64px auto 0;
+  margin: 0 auto 0;
+
   padding-top: 32px;
 }
 .inner-title {
@@ -198,6 +200,7 @@ const onClick = async () => {
 
 //生徒用画面ボタンエリア
 .button-area {
+  height: 64px;
   text-align: right;
   margin-right: min(5%, 20px);
 }

--- a/frontend/pages/teachersLogin.vue
+++ b/frontend/pages/teachersLogin.vue
@@ -136,9 +136,7 @@ const onClick = async () => {
 .container {
   width: 450px;
   height: 600px;
-  // margin: 64px auto 0;
-  margin: 0 auto 0;
-
+  margin: 0 auto;
   padding-top: 32px;
 }
 .inner-title {


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-100

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
・ログイン画面に生徒用画面に遷移するボタンを追加
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/77389ed1-8415-41df-9c98-dfbcba0bf705)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
