### PR TITLE
科目、教師のinputにplaceholderを追加

### DIFF
--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -14,6 +14,7 @@
               id="subject"
               maxlength="10"
               required
+              placeholder="「クリア」で削除"
             />
             <div v-if="!isValidSubject" class="font-size-xs red inner-title__err validate">
               科目名を入力してください
@@ -29,6 +30,7 @@
               id="teacher"
               maxlength="10"
               required
+              placeholder="「クリア」で削除"
             />
             <div v-if="!isValidTeacher" class="font-size-xs red inner-title__err validate">
               教師名を入力してください


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-104

# 変更内容
- 科目を入力するinputにplaceholderを追加
- 教師を入力するinputにplaceholderを追加
<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024649/21af98f4-d442-4c3c-8ad8-bdc5ce48d65e)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
