### PR TITLE
実装/フロント_登録/更新画面_デザイン崩れ修正

### DIFF
--- a/frontend/assets/scss/timetable.scss
+++ b/frontend/assets/scss/timetable.scss
@@ -15,7 +15,6 @@
 //PC用scss
 @media screen and (min-width: 768px) {
   .timetable {
-    background-color: #5160ae;
     writing-mode: vertical-lr;
     border-collapse: collapse;
     table-layout: fixed;

--- a/frontend/assets/scss/timetable.scss
+++ b/frontend/assets/scss/timetable.scss
@@ -15,6 +15,7 @@
 //PC用scss
 @media screen and (min-width: 768px) {
   .timetable {
+    background-color: #5160ae;
     writing-mode: vertical-lr;
     border-collapse: collapse;
     table-layout: fixed;
@@ -27,11 +28,6 @@
   .register {
     width: 1120px;
     height: 580px;
-    margin-top: 20px;
-    margin-left: 24px;
-    position: absolute;
-    top: 220px;
-    left: 224px;
   }
   .horizontal-writing {
     box-shadow: 0 0 0 1px #333 inset;

--- a/frontend/components/default-layout.vue
+++ b/frontend/components/default-layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="root">
     <Header :page-name="props.pageName" />
     <main>
       <slot></slot>
@@ -19,3 +19,8 @@ const props = defineProps({
   },
 })
 </script>
+<style lang="scss" scoped>
+.root {
+  height: 100vh;
+}
+</style>

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -13,34 +13,26 @@
       >
       </calendar-modal>
     </div>
+    <div class="main">
+      <div class="timetable-button-area">
+        <button class="usual-button home font-size-l" type="button" @click="() => navigateTo('/home')">ホーム</button>
 
-    <p>
-      <button class="usual-button home" type="button" @click="() => navigateTo('/home')">
-        <div class="font-size-l">ホーム</div>
-      </button>
-    </p>
+        <button class="usual-button student-home font-size-m" type="button" @click="open">生徒用画面確認</button>
 
-    <p>
-      <button class="usual-button student-home" type="button" @click="open">
-        <div class="font-size-m">生徒用画面確認</div>
-      </button>
-    </p>
-
-    <p>
-      <button class="usual-button logout" type="button" @click="commonLogout">
-        <div class="font-size-l">ログアウト</div>
-      </button>
-    </p>
-
-    <TimetableComponentRegister v-model:timetables="timetables"></TimetableComponentRegister>
-    <p>
-      <button class="usual-button back-home" type="button" @click="() => navigateTo('/home')">
-        <div class="font-size-l">戻る</div>
-      </button>
-      <button class="unusual-button timetable-update" type="button" @click="useState">
-        <div class="font-size-l">時間割更新</div>
-      </button>
-    </p>
+        <button class="usual-button logout font-size-l" type="button" @click="commonLogout">ログアウト</button>
+      </div>
+      <div class="timtetable-area">
+        <TimetableComponentRegister v-model:timetables="timetables"></TimetableComponentRegister>
+      </div>
+      <div class="bottom">
+        <button class="usual-button back-home" type="button" @click="() => navigateTo('/home')">
+          <div class="font-size-l">戻る</div>
+        </button>
+        <button class="unusual-button timetable-update" type="button" @click="useState">
+          <div class="font-size-l">時間割更新</div>
+        </button>
+      </div>
+    </div>
   </default-layout>
 </template>
 
@@ -140,9 +132,9 @@ input {
   font-size: 24px;
 }
 
-.home {
-  margin-top: 66px;
-}
+// .home {
+//   margin-top: 66px;
+// }
 
 .back-home {
   position: absolute;
@@ -153,6 +145,28 @@ input {
   position: absolute;
   left: 960px;
   top: 888px;
+}
+
+.timtetable-area {
+  margin-top: 180px;
+}
+
+.register {
+  margin-top: 60px;
+  margin-left: 0px;
+}
+
+.timetable-button-area {
+  margin-top: 80px;
+  width: 14%;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.bottom {
+  width: 100%;
+  padding: 0 80px;
 }
 
 // カレンダーダイアログのscss

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -1,18 +1,5 @@
 <template>
   <default-layout page-name="教師用登録ページ">
-    <div class="date-set">
-      <button class="usual-button start-end-date" type="button" @click="onclick">
-        <div class="font-size-m">開始日終了日選択</div>
-      </button>
-      <label v-if="isDisplayableTerm" class="datetext">{{ start }}~{{ end }}</label>
-      <calendar-modal
-        :is-shown="isShown"
-        @update:value="selectDate"
-        selection-type="range"
-        @on-close="() => (isShown = false)"
-      >
-      </calendar-modal>
-    </div>
     <div class="main">
       <div class="timetable-button-area">
         <button class="usual-button home font-size-l" type="button" @click="() => navigateTo('/home')">ホーム</button>
@@ -21,16 +8,32 @@
 
         <button class="usual-button logout font-size-l" type="button" @click="commonLogout">ログアウト</button>
       </div>
-      <div class="timtetable-area">
+
+      <div class="timetable-wrapper">
+        <div class="date-set">
+          <button class="usual-button start-end-date" type="button" @click="onclick">
+            <div class="font-size-m">開始日終了日選択</div>
+          </button>
+          <label v-if="isDisplayableTerm" class="datetext">{{ start }}~{{ end }}</label>
+          <calendar-modal
+            :is-shown="isShown"
+            @update:value="selectDate"
+            selection-type="range"
+            @on-close="() => (isShown = false)"
+          >
+          </calendar-modal>
+        </div>
         <TimetableComponentRegister v-model:timetables="timetables"></TimetableComponentRegister>
-      </div>
-      <div class="bottom">
-        <button class="usual-button back-home" type="button" @click="() => navigateTo('/home')">
-          <div class="font-size-l">戻る</div>
-        </button>
-        <button class="unusual-button timetable-update" type="button" @click="useState">
-          <div class="font-size-l">時間割更新</div>
-        </button>
+        <div class="bottom">
+          <div class="bottom-button-area">
+            <button class="usual-button back-home" type="button" @click="() => navigateTo('/home')">
+              <div class="font-size-l">戻る</div>
+            </button>
+            <button class="unusual-button timetable-update" type="button" @click="useState">
+              <div class="font-size-l">時間割更新</div>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </default-layout>
@@ -122,7 +125,7 @@ input {
 }
 
 .date-set {
-  padding-left: 380px;
+  margin-left: 180px;
   font-size: 24px;
   margin-top: 16px;
 }
@@ -132,33 +135,16 @@ input {
   font-size: 24px;
 }
 
-// .home {
-//   margin-top: 66px;
-// }
-
-.back-home {
-  position: absolute;
-  left: 320px;
-  top: 888px;
-}
-.timetable-update {
-  position: absolute;
-  left: 960px;
-  top: 888px;
-}
-
-.timtetable-area {
-  margin-top: 180px;
-}
-
-.register {
-  margin-top: 60px;
-  margin-left: 0px;
+.main {
+  display: flex;
+  height: calc(100vh - 100px);
+  margin-bottom: min(10px, 5%);
 }
 
 .timetable-button-area {
-  margin-top: 80px;
-  width: 14%;
+  margin-top: 200px;
+  padding: auto;
+  width: min(20%, 250px);
   display: flex;
   flex-direction: column;
   text-align: center;
@@ -167,6 +153,11 @@ input {
 .bottom {
   width: 100%;
   padding: 0 80px;
+}
+.bottom-button-area {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
 }
 
 // カレンダーダイアログのscss

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -216,7 +216,7 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
   box-shadow: 0 0 0 1px #333 inset;
 }
 .time-area {
-  height: 180px;
+  height: 150px;
 }
 .time-area-text {
   text-align: center;
@@ -232,10 +232,7 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
 .right_area {
   display: flex;
 }
-.left-button {
-  margin-left: 24px;
-  margin-bottom: 24px;
-}
+
 .timetable-button-area {
   width: 14%;
   display: flex;

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -205,13 +205,8 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
 @import '../assets/scss/timetable.scss';
 
 .timetable {
-  writing-mode: vertical-lr;
-  border-collapse: collapse;
-  table-layout: fixed;
   width: 1120px;
   height: 580px;
-  background-color: #ffffff;
-  box-shadow: 0 0 0 1px #333 inset;
 }
 
 .update {

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -1,13 +1,6 @@
 <template>
   <default-layout page-name="教師用更新ページ">
     <!-- html記述場所 -->
-    <!--時間表示場所-->
-    <div class="time-area">
-      <div class="time-area-text">
-        <div class="font-size-xl">この時間割を登録しますか？</div>
-        <div class="time-area-text-margin font-size-l">{{ time?.start }} ~ {{ time?.end }}</div>
-      </div>
-    </div>
     <div class="main">
       <!--ボタン-->
       <div class="timetable-button-area">
@@ -19,43 +12,53 @@
           ログアウト
         </button>
       </div>
-      <!--時間割エリア-->
-      <div class="right-area">
-        <table class="timetable-update">
-          <!--時間割-->
-          <!--最初の列 空白と時間割の時限を置く-->
-          <tr>
-            <th class="dayOfWeek-head horizontal-writing"></th>
-            <!--時限表示ループ-->
-            <template v-for="periodNumber of periodCount" :key="periodNumber">
-              <TimetablePeriod :period="periodNumber"></TimetablePeriod>
-            </template>
-          </tr>
-          <template v-for="dayOfWeek in dayOfWeekCount" :key="dayOfWeek">
-            <tr>
-              <TimetableDayOfWeek
-                :day-of-week="dayOfWeekChangeString(dayOfWeekNumber[dayOfWeek - 1])"
-              ></TimetableDayOfWeek>
-              <template v-for="period in periodCount" :key="period">
-                <template v-if="lessonExist(period, dayOfWeek)">
-                  <!--データがある時-->
-                  <TimetableLesson
-                    :is-holiday="false"
-                    :subject="getSubject(period, dayOfWeek)"
-                    :teacher-name="getTeacher(period, dayOfWeek)"
-                    :is-unavailable="false"
-                  />
+      <div class="timetable-wrapper">
+        <!--時間表示場所-->
+        <div class="time-area">
+          <div class="time-area-text">
+            <div class="font-size-xl">この時間割を登録しますか？</div>
+            <div class="time-area-text-margin font-size-l">{{ time?.start }} ~ {{ time?.end }}</div>
+          </div>
+        </div>
+        <!--時間割エリア-->
+        <div class="right-area">
+          <table class="timetable update">
+            <tbody>
+              <!--時間割-->
+              <!--最初の列 空白と時間割の時限を置く-->
+              <tr>
+                <th class="dayOfWeek-head horizontal-writing"></th>
+                <!--時限表示ループ-->
+                <template v-for="periodNumber of periodCount" :key="periodNumber">
+                  <TimetablePeriod :period="periodNumber"></TimetablePeriod>
                 </template>
+              </tr>
+              <template v-for="dayOfWeek in dayOfWeekCount" :key="dayOfWeek">
+                <tr>
+                  <TimetableDayOfWeek
+                    :day-of-week="dayOfWeekChangeString(dayOfWeekNumber[dayOfWeek - 1])"
+                  ></TimetableDayOfWeek>
+                  <template v-for="period in periodCount" :key="period">
+                    <template v-if="lessonExist(period, dayOfWeek)">
+                      <!--データがある時-->
+                      <TimetableLesson
+                        :is-holiday="false"
+                        :subject="getSubject(period, dayOfWeek)"
+                        :teacher-name="getTeacher(period, dayOfWeek)"
+                        :is-unavailable="false"
+                      />
+                    </template>
 
-                <template v-else>
-                  <!--データがないとき-->
-                  <TimetableLesson :is-holiday="false" :is-unavailable="false" />
-                </template>
+                    <template v-else>
+                      <!--データがないとき-->
+                      <TimetableLesson :is-holiday="false" :is-unavailable="false" />
+                    </template>
+                  </template>
+                </tr>
               </template>
-            </tr>
-          </template>
-        </table>
-
+            </tbody>
+          </table>
+        </div>
         <div class="bottom">
           <div class="bottom-button-area">
             <div class="bottom-left-button">
@@ -207,13 +210,19 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
 
 <style scoped lang="scss">
 @import '../assets/scss/timetable.scss';
-.timetable-update {
+
+.timetable {
   writing-mode: vertical-lr;
   border-collapse: collapse;
   table-layout: fixed;
-
+  width: 1120px;
+  height: 580px;
   background-color: #ffffff;
   box-shadow: 0 0 0 1px #333 inset;
+}
+
+.update {
+  margin-left: 0px;
 }
 .time-area {
   height: 150px;
@@ -228,17 +237,22 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
 /* メイン */
 .main {
   display: flex;
+  margin-bottom: min(10px, 5%);
 }
 .right_area {
   display: flex;
+  margin-left: 24px;
 }
 
 .timetable-button-area {
-  width: 14%;
+  margin-top: 200px;
+  padding: auto;
+  width: min(20%, 250px);
   display: flex;
   flex-direction: column;
   text-align: center;
 }
+
 /*下部 */
 .bottom {
   width: 100%;
@@ -248,16 +262,11 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
   color: #5160ae;
 }
 .bottom-button-area {
-  position: relative;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
 }
-.bottom-left-button {
-  position: absolute;
-  left: 24px;
-}
-.bottom-right-button {
-  position: absolute;
-  right: 24px;
-}
+
 .important-button {
   background-color: #5160ae;
   width: 160px;


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-102

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

・デザイン崩れの修正
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/0e469875-53e8-4211-8153-7d3fce283dc2)
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/54eee51c-4782-43c5-aaf6-6fce3473c488)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
