### PR TITLE
実装/フロント_timetable,button位置変更

### DIFF
--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -218,7 +218,7 @@ watch(
 
 <style scoped lang="scss">
 .container {
-  margin: 15px min(10%, 20px) 15px 0;
+  margin: 0 min(10%, 20px) 15px 0;
 }
 /* 三角関連 */
 .triangle-button-area {
@@ -273,11 +273,9 @@ watch(
 .timetable-wrapper {
   margin-bottom: min(80px, 10%);
 }
-button {
-  margin-bottom: 24px;
-}
+
 .timetable-button-area {
-  margin-top: 120px;
+  margin-top: 200px;
   padding: auto;
   width: min(20%, 250px);
   display: flex;

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -161,7 +161,6 @@ input {
 .bottom-button-area {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 10px;
 }
 
 // カレンダーダイアログのscss

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -142,7 +142,7 @@ input {
 }
 
 .register {
-  margin-top: 80px;
+  margin-top: 100px;
 }
 
 .timetable-button-area {

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -252,7 +252,6 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
 .bottom-button-area {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 10px;
 }
 
 .important-button {

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -213,7 +213,7 @@ function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
   margin-left: 0px;
 }
 .time-area {
-  height: 150px;
+  height: 170px;
 }
 .time-area-text {
   text-align: center;


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-107

# 変更内容

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

・一覧画面のボタン位置等変更
・登録画面、更新画面の時間割の位置変更

一覧画面
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/5fc89c20-e2da-4e6e-8b8a-cb6fe2a72fbb)
登録画面
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/73c6bdf3-a816-46b9-8e15-4c67c6cac260)
更新画面
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024690/77f610f9-6c3a-489f-85b9-c12fc51f5571)


---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
