### PR TITLE
削除機能追加

### DIFF
--- a/backend/app/Http/Controllers/RegisterController.php
+++ b/backend/app/Http/Controllers/RegisterController.php
@@ -17,6 +17,7 @@ class RegisterController extends Controller
             $start = $request->input('time.start');
             $end = $request->input('time.end');
             $lessons = $request->collect('lessons');
+            $isClear = $request->input('isClear');
 
             foreach ($lessons as $class) {
                 $post = new Timetable();
@@ -25,11 +26,9 @@ class RegisterController extends Controller
                 $dayOfWeek = $class['dayOfWeek'];
                 $period = $class['period'];
                 $subject = $class['subject'];
-                if ($subject === "クリア") {
-                    $subject = "";
-                }
                 $teacher = $class['teacher'];
-                if ($teacher === "クリア") {
+                if ($isClear === true) {
+                    $subject = "";
                     $teacher = "";
                 }
                 $post->day_of_week = $dayOfWeek;

--- a/backend/app/Http/Controllers/RegisterController.php
+++ b/backend/app/Http/Controllers/RegisterController.php
@@ -25,7 +25,13 @@ class RegisterController extends Controller
                 $dayOfWeek = $class['dayOfWeek'];
                 $period = $class['period'];
                 $subject = $class['subject'];
+                if ($subject === "クリア") {
+                    $subject = "";
+                }
                 $teacher = $class['teacher'];
+                if ($teacher === "クリア") {
+                    $teacher = "";
+                }
                 $post->day_of_week = $dayOfWeek;
                 $post->period = $period;
                 $post->subject = $subject;

--- a/backend/app/Http/Controllers/RegisterController.php
+++ b/backend/app/Http/Controllers/RegisterController.php
@@ -17,7 +17,6 @@ class RegisterController extends Controller
             $start = $request->input('time.start');
             $end = $request->input('time.end');
             $lessons = $request->collect('lessons');
-            $isClear = $request->input('isClear');
 
             foreach ($lessons as $class) {
                 $post = new Timetable();
@@ -27,9 +26,10 @@ class RegisterController extends Controller
                 $period = $class['period'];
                 $subject = $class['subject'];
                 $teacher = $class['teacher'];
+                $isClear = $class['isClear'];
                 if ($isClear === true) {
-                    $subject = "";
-                    $teacher = "";
+                    $subject = '';
+                    $teacher = '';
                 }
                 $post->day_of_week = $dayOfWeek;
                 $post->period = $period;

--- a/backend/app/Http/Requests/RegisterPostRequest.php
+++ b/backend/app/Http/Requests/RegisterPostRequest.php
@@ -2,10 +2,8 @@
 
 namespace App\Http\Requests;
 
-
 use Illuminate\Foundation\Http\FormRequest;
 
-// use Illuminate\Support\Facades\Response;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -31,15 +29,16 @@ class RegisterPostRequest extends FormRequest
     public function rules()
     {
         $latestDate = date("Y", strtotime("1  year")) . '-12-31';
-        return [
+        $rules = [
             'time.start' => 'required|date_format:"Y-m-d"|after_or_equal:2015-01-01|before_or_equal:' . $latestDate,
             'time.end' => 'required|date_format:"Y-m-d"|after_or_equal:time.start|before_or_equal:' . $latestDate,
             'lessons' => 'required|array',
-            'lessons.*.subject' => 'required_with:lessons|string|max:10',
-            'lessons.*.teacher' => 'required_with:lessons|string|max:10',
+            'lessons.*.subject' => 'exclude_unless:lessons.*.isClear,false|required_with:lessons|string|max:10',
+            'lessons.*.teacher' => 'exclude_unless:lessons.*.isClear,false|required_with:lessons|string|max:10',
             'lessons.*.dayOfWeek' => 'required_with:lessons|integer|min:0|max:6',
-            'lessons.*.period' => 'required_with:lessons|integer|min:1|max:6'
+            'lessons.*.period' => 'required_with:lessons|integer|min:1|max:6',
         ];
+        return $rules;
     }
 
 

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -5,40 +5,36 @@
         <form class="form-example" @submit="regist">
           <div class="register-modal-header font-size-l">{{ props.dayOfWeek }}曜{{ props.period }}時間目</div>
           <div class="subject-form font-size-l">
-            <label for="subject"
-              >科目：
-              <input
-                type="text"
-                v-model="subject"
-                class="subject-teacher-input"
-                maxlength="10"
-                :required="!isClear"
-                :disabled="isClear"
-              />
-            </label>
+            科目：
+            <input
+              type="text"
+              v-model="subject"
+              class="subject-teacher-input"
+              maxlength="10"
+              :required="!isClear"
+              :disabled="isClear"
+            />
             <div v-if="!isValidSubject" class="font-size-xs red inner-title__err validate">
               科目名を入力してください
             </div>
           </div>
           <div class="teacher-form font-size-l">
-            <label for="teacher"
-              >教師：
-              <input
-                type="text"
-                v-model="teacher"
-                class="subject-teacher-input"
-                maxlength="10"
-                :required="!isClear"
-                :disabled="isClear"
-              />
-            </label>
+            教師：
+            <input
+              type="text"
+              v-model="teacher"
+              class="subject-teacher-input"
+              maxlength="10"
+              :required="!isClear"
+              :disabled="isClear"
+            />
             <div v-if="!isValidTeacher" class="font-size-xs red inner-title__err validate">
               教師名を入力してください
             </div>
           </div>
           <div class="clear-checkbox-set font-size-m">
-            <label for="check1">
-              <input type="checkbox" id="check1" class="clear-checkbox" v-model="isClear" />
+            <label for="is-chech">
+              <input type="checkbox" id="is-check" class="clear-checkbox" v-model="isClear" />
               授業削除
             </label>
           </div>

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -75,7 +75,6 @@ defineExpose({
     subject.value = ''
     teacher.value = ''
     isClear.value = false
-    console.log('clear')
   },
 })
 
@@ -95,7 +94,6 @@ const props = withDefaults(defineProps<ModalBaseProps>(), {
 const emit = defineEmits(['submit', 'onClose'])
 
 function regist(e: Event) {
-  console.log('regist')
   e.preventDefault()
   isValidSubject.value = subject.value.length !== 0 || isClear.value
   isValidTeacher.value = teacher.value.length !== 0 || isClear.value

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -125,6 +125,8 @@ defineExpose({
 
 function displayInput() {
   if (checked.value === true) {
+    subject.value = ''
+    teacher.value = ''
     return true
   }
   return false

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -34,7 +34,7 @@
               教師名を入力してください
             </div>
           </div>
-
+          <input type="checkbox" id="check1" v-model="checked" />この授業を削除
           <button type="button" class="usual-button cancel-button" @click.stop="onClose">
             <div class="font-size-l">キャンセル</div>
           </button>
@@ -53,6 +53,9 @@ import ModalBase from './modal-base.vue'
 
 const subject = ref('')
 const teacher = ref('')
+const isClear = ref(false)
+
+const checked = ref(false)
 
 const isValidSubject = ref(true)
 const isValidTeacher = ref(true)
@@ -60,6 +63,7 @@ const isValidTeacher = ref(true)
 export interface Submit {
   subject: string
   teacher: string
+  isClear: boolean
 }
 
 interface ModalBaseProps {
@@ -84,8 +88,21 @@ function regist(e: Event) {
   e.preventDefault()
   isValidSubject.value = subject.value.length !== 0
   isValidTeacher.value = teacher.value.length !== 0
-  if (isValidSubject.value && isValidTeacher.value) {
-    emit('submit', { subject: subject.value, teacher: teacher.value })
+  console.log(checked.value)
+  if (checked.value) {
+    isClear.value = true
+  } else {
+    isClear.value = false
+  }
+
+  if (checked.value) {
+    subject.value = '削除'
+    teacher.value = ''
+    emit('submit', { subject: subject.value, teacher: teacher.value, isClear: isClear.value })
+  } else {
+    if (isValidSubject.value && isValidTeacher.value) {
+      emit('submit', { subject: subject.value, teacher: teacher.value, isClear: isClear.value })
+    }
   }
 }
 

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -58,15 +58,6 @@
 import { ref } from 'vue'
 import ModalBase from './modal-base.vue'
 
-const subject = ref('')
-const teacher = ref('')
-const isClear = ref(false)
-
-const checked = ref(false)
-
-const isValidSubject = ref(true)
-const isValidTeacher = ref(true)
-
 export interface Submit {
   subject: string
   teacher: string
@@ -78,6 +69,24 @@ interface ModalBaseProps {
   dayOfWeek: string
   period: number
 }
+
+defineExpose({
+  clear() {
+    subject.value = ''
+    teacher.value = ''
+    isClear.value = false
+    console.log('clear')
+  },
+})
+
+const subject = ref('')
+const teacher = ref('')
+const isClear = ref(false)
+
+const checked = ref(false)
+
+const isValidSubject = ref(true)
+const isValidTeacher = ref(true)
 
 const props = withDefaults(defineProps<ModalBaseProps>(), {
   isShown: false,
@@ -113,15 +122,6 @@ function regist(e: Event) {
 function onClose() {
   emit('onClose')
 }
-
-defineExpose({
-  clear() {
-    subject.value = ''
-    teacher.value = ''
-    isClear.value = false
-    console.log('clear')
-  },
-})
 
 function displayInput() {
   if (checked.value === true) {

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -5,40 +5,41 @@
         <form class="form-example" @submit="regist">
           <div class="register-modal-header font-size-l">{{ props.dayOfWeek }}曜{{ props.period }}時間目</div>
           <div class="subject-form font-size-l">
-            <label for="subject">科目：</label>
-            <input
-              type="text"
-              v-model="subject"
-              class="subject-input"
-              name="subject-input"
-              id="subject-input"
-              maxlength="10"
-              required
-              :disabled="displayInput()"
-            />
+            <label for="subject"
+              >科目：
+              <input
+                type="text"
+                v-model="subject"
+                class="subject-teacher-input"
+                maxlength="10"
+                :required="!isClear"
+                :disabled="isClear"
+                :readonly="isClear"
+              />
+            </label>
             <div v-if="!isValidSubject" class="font-size-xs red inner-title__err validate">
               科目名を入力してください
             </div>
           </div>
           <div class="teacher-form font-size-l">
-            <label for="teacher">教師：</label>
-            <input
-              type="text"
-              v-model="teacher"
-              class="teacher-input"
-              name="teacher-input"
-              id="teacher-input"
-              maxlength="10"
-              required
-              :disabled="displayInput()"
-            />
+            <label for="teacher"
+              >教師：
+              <input
+                type="text"
+                v-model="teacher"
+                class="subject-teacher-input"
+                maxlength="10"
+                :required="!isClear"
+                :disabled="isClear"
+              />
+            </label>
             <div v-if="!isValidTeacher" class="font-size-xs red inner-title__err validate">
               教師名を入力してください
             </div>
           </div>
           <div class="clear-checkbox-set font-size-m">
             <label for="check1">
-              <input type="checkbox" id="check1" class="clear-checkbox" v-model="checked" />
+              <input type="checkbox" id="check1" class="clear-checkbox" v-model="isClear" />
               授業削除
             </label>
           </div>
@@ -83,8 +84,6 @@ const subject = ref('')
 const teacher = ref('')
 const isClear = ref(false)
 
-const checked = ref(false)
-
 const isValidSubject = ref(true)
 const isValidTeacher = ref(true)
 
@@ -97,17 +96,12 @@ const props = withDefaults(defineProps<ModalBaseProps>(), {
 const emit = defineEmits(['submit', 'onClose'])
 
 function regist(e: Event) {
+  console.log('regist')
   e.preventDefault()
-  isValidSubject.value = subject.value.length !== 0
-  isValidTeacher.value = teacher.value.length !== 0
+  isValidSubject.value = subject.value.length !== 0 || isClear.value
+  isValidTeacher.value = teacher.value.length !== 0 || isClear.value
 
-  if (checked.value) {
-    isClear.value = true
-  } else {
-    isClear.value = false
-  }
-
-  if (checked.value) {
+  if (isClear.value) {
     subject.value = ''
     teacher.value = ''
     emit('submit', { subject: subject.value, teacher: teacher.value, isClear: isClear.value })
@@ -116,21 +110,19 @@ function regist(e: Event) {
       emit('submit', { subject: subject.value, teacher: teacher.value, isClear: isClear.value })
     }
   }
-  checked.value = false
 }
 
 function onClose() {
   emit('onClose')
 }
 
-function displayInput() {
-  if (checked.value === true) {
+watch(
+  () => isClear.value,
+  () => {
     subject.value = ''
     teacher.value = ''
-    return true
   }
-  return false
-}
+)
 </script>
 
 <style lang="scss" scoped>
@@ -182,11 +174,11 @@ div {
   margin-left: 108px;
   margin-top: 40px;
 }
-.subject-input {
+.subject-teacher-input {
   border: 1px solid black;
-}
 
-.teacher-input {
-  border: 1px solid black;
+  &:disabled {
+    background: #a9a9a9;
+  }
 }
 </style>

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -14,7 +14,6 @@
                 maxlength="10"
                 :required="!isClear"
                 :disabled="isClear"
-                :readonly="isClear"
               />
             </label>
             <div v-if="!isValidSubject" class="font-size-xs red inner-title__err validate">

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -10,10 +10,11 @@
               type="text"
               v-model="subject"
               class="subject-input"
-              name="subject"
-              id="subject"
+              name="subject-input"
+              id="subject-input"
               maxlength="10"
               required
+              :disabled="displayInput()"
             />
             <div v-if="!isValidSubject" class="font-size-xs red inner-title__err validate">
               科目名を入力してください
@@ -25,16 +26,22 @@
               type="text"
               v-model="teacher"
               class="teacher-input"
-              name="teacher"
-              id="teacher"
+              name="teacher-input"
+              id="teacher-input"
               maxlength="10"
               required
+              :disabled="displayInput()"
             />
             <div v-if="!isValidTeacher" class="font-size-xs red inner-title__err validate">
               教師名を入力してください
             </div>
           </div>
-          <input type="checkbox" id="check1" v-model="checked" />この授業を削除
+          <div class="clear-checkbox-set font-size-m">
+            <label for="check1">
+              <input type="checkbox" id="check1" class="clear-checkbox" v-model="checked" />
+              授業削除
+            </label>
+          </div>
           <button type="button" class="usual-button cancel-button" @click.stop="onClose">
             <div class="font-size-l">キャンセル</div>
           </button>
@@ -72,10 +79,6 @@ interface ModalBaseProps {
   period: number
 }
 
-interface ModalBaseEmit {
-  (e: 'submit', value: Submit): void
-}
-
 const props = withDefaults(defineProps<ModalBaseProps>(), {
   isShown: false,
   dayOfWeek: '',
@@ -88,7 +91,7 @@ function regist(e: Event) {
   e.preventDefault()
   isValidSubject.value = subject.value.length !== 0
   isValidTeacher.value = teacher.value.length !== 0
-  console.log(checked.value)
+
   if (checked.value) {
     isClear.value = true
   } else {
@@ -96,7 +99,7 @@ function regist(e: Event) {
   }
 
   if (checked.value) {
-    subject.value = '削除'
+    subject.value = ''
     teacher.value = ''
     emit('submit', { subject: subject.value, teacher: teacher.value, isClear: isClear.value })
   } else {
@@ -104,10 +107,27 @@ function regist(e: Event) {
       emit('submit', { subject: subject.value, teacher: teacher.value, isClear: isClear.value })
     }
   }
+  checked.value = false
 }
 
 function onClose() {
   emit('onClose')
+}
+
+defineExpose({
+  clear() {
+    subject.value = ''
+    teacher.value = ''
+    isClear.value = false
+    console.log('clear')
+  },
+})
+
+function displayInput() {
+  if (checked.value === true) {
+    return true
+  }
+  return false
 }
 </script>
 
@@ -123,21 +143,30 @@ div {
 
 .register-modal-header {
   text-align: center;
-  padding-top: 12px;
+  padding-top: 2%;
+}
+
+.clear-checkbox-set {
+  text-align: center;
+  margin-top: 8%;
+}
+.clear-checkbox {
+  transform: scale(2);
+  margin-right: 2%;
 }
 .cancel-button {
   text-align: center;
-  margin-left: 64px;
-  margin-top: 104px;
+  margin-left: 10%;
+  margin-top: 5%;
 }
 
 .validate {
-  margin-left: 72px;
-  position: absolute;
+  margin-left: 5%;
+  position: fixed;
 }
 .register-button {
   text-align: center;
-  margin-left: 152px;
+  margin-left: 25%;
 }
 
 .subject-form {

--- a/frontend/components/subject-teacher-register-modal.vue
+++ b/frontend/components/subject-teacher-register-modal.vue
@@ -33,7 +33,7 @@
             </div>
           </div>
           <div class="clear-checkbox-set font-size-m">
-            <label for="is-chech">
+            <label for="is-check">
               <input type="checkbox" id="is-check" class="clear-checkbox" v-model="isClear" />
               授業削除
             </label>

--- a/frontend/components/timetable-component-register.vue
+++ b/frontend/components/timetable-component-register.vue
@@ -22,6 +22,7 @@
               :period="index + 1"
               v-model:subject="lesson.subject"
               v-model:teacher-name="lesson.teacher"
+              v-model:isClear="lesson.isClear"
             >
             </TimetableLessonRegister>
           </template>

--- a/frontend/components/timetable-lesson-register.vue
+++ b/frontend/components/timetable-lesson-register.vue
@@ -9,12 +9,13 @@
           @on-close="() => (isShown = false)"
           :dayOfWeek="props.dayOfWeek"
           :period="props.period"
+          ref="modal"
         >
         </subject-teacher-register-modal>
         <button class="delete-button font-size-m" @click="deleteClass">消</button>
       </div>
       <div>
-        <p class="lesson-cell-box" :class="[fontSizeClass('subject')]">{{ updateSubject }}</p>
+        <p class="lesson-cell-box" :class="[fontSizeClass('subject')]">{{ displaySubject }}</p>
         <p class="lesson-cell-box" :class="[fontSizeClass('teacher')]">{{ updateTeacher }}</p>
       </div>
     </div>
@@ -24,6 +25,9 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { Submit } from './subject-teacher-register-modal.vue'
+import { SubjectTeacherRegisterModalMethod } from '~/types/SubjectTeacherRegisterModalMethod'
+
+const modal = ref<SubjectTeacherRegisterModalMethod>()
 
 const isShown = ref(false)
 
@@ -39,6 +43,7 @@ function deleteClass() {
   emit('update:subject', updateSubject.value)
   emit('update:teacherName', updateTeacher.value)
   emit('update:isClear', updateIsClear.value)
+  modal.value?.clear()
 }
 
 const props = defineProps({
@@ -65,6 +70,12 @@ const emit = defineEmits(['update:subject', 'update:teacherName', 'update:isClea
 const updateSubject = ref('')
 const updateTeacher = ref('')
 const updateIsClear = ref(false)
+const displaySubject = computed(() => {
+  if (updateIsClear.value) {
+    return '削除'
+  }
+  return updateSubject.value
+})
 function submit(submit: Submit) {
   updateSubject.value = submit.subject
   updateTeacher.value = submit.teacher

--- a/frontend/components/timetable-lesson-register.vue
+++ b/frontend/components/timetable-lesson-register.vue
@@ -31,11 +31,14 @@ function onclick() {
   isShown.value = !isShown.value
 }
 
+/* 消ボタンの処理 */
 function deleteClass() {
   updateSubject.value = ''
   updateTeacher.value = ''
+  updateIsClear.value = false
   emit('update:subject', updateSubject.value)
   emit('update:teacherName', updateTeacher.value)
+  emit('update:isClear', updateIsClear.value)
 }
 
 const props = defineProps({
@@ -57,15 +60,18 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['update:subject', 'update:teacherName'])
+const emit = defineEmits(['update:subject', 'update:teacherName', 'update:isClear'])
 
 const updateSubject = ref('')
 const updateTeacher = ref('')
+const updateIsClear = ref(false)
 function submit(submit: Submit) {
   updateSubject.value = submit.subject
   updateTeacher.value = submit.teacher
+  updateIsClear.value = submit.isClear
   emit('update:subject', updateSubject.value)
   emit('update:teacherName', updateTeacher.value)
+  emit('update:isClear', updateIsClear.value)
   isShown.value = false
 }
 

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -57,6 +57,7 @@ function onclick() {
   isShown.value = !isShown.value
 }
 
+/* 生徒用画面へ遷移 */
 function open() {
   window.open('/studentHome', '_blank', 'noreferrer')
 }
@@ -84,6 +85,7 @@ function useState() {
             teacher: lesson.teacher,
             period: index + 1,
             dayOfWeek: timetable.dayOfWeek,
+            isClear: lesson.isClear,
           }
         })
         .filter((lesson) => lesson.subject.length || lesson.teacher.length)
@@ -102,10 +104,7 @@ function useState() {
   }
 }
 
-const today = new Date()
-console.log(today)
-
-/* 検証用オブジェクト */
+/* 初期オブジェクト */
 const timetables: Timetable[] = Object.entries(DAY_OF_WEEK).map<Timetable>(([_, value]) => ({
   dayOfWeek: value,
   isHoliday: false,
@@ -114,6 +113,7 @@ const timetables: Timetable[] = Object.entries(DAY_OF_WEEK).map<Timetable>(([_, 
   lessons: [...Array(6)].map<Lesson>((_) => ({
     subject: '',
     teacher: '',
+    isClear: false,
   })),
 }))
 

--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -86,9 +86,7 @@ function useState() {
         .filter((lesson) => lesson.subject.length || lesson.teacher.length)
     )
     .flat()
-  console.log(useTimetables().lessons.value)
   useTimetables().time.value = { start: start.value, end: end.value }
-  console.log(useTimetables().time.value)
 
   if (start.value == undefined || end.value == undefined) {
     alert('開始日終了日を選択してください')

--- a/frontend/types/SubjectTeacherRegisterModalMethod.ts
+++ b/frontend/types/SubjectTeacherRegisterModalMethod.ts
@@ -1,0 +1,3 @@
+export interface SubjectTeacherRegisterModalMethod {
+  clear(): void
+}

--- a/frontend/types/request/timetablesRegisterRequest.ts
+++ b/frontend/types/request/timetablesRegisterRequest.ts
@@ -3,6 +3,7 @@ export interface Lesson {
   teacher: string
   dayOfWeek: number
   period: number
+  isClear: boolean
 }
 
 export interface Time {

--- a/frontend/types/response/timetablesAcquireResponse.ts
+++ b/frontend/types/response/timetablesAcquireResponse.ts
@@ -10,4 +10,5 @@ export interface Timetable {
 export interface Lesson {
   subject: string
   teacher: string
+  isClear: boolean
 }


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-101

# 変更内容

- 登録ダイアログに授業削除チェックボックスを追加
- isClear変数を追加
- 時間割登録APIのバリデーションチェックを修正
- 授業セルの時間割削除ボタンを押下すると科目名、教師名をクリアするように修正

<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->
・授業削除チェックボックスをチェックしていない場合
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024649/9f8691f8-8294-45bf-958c-203b175612a8)
・授業削除チェックボックスをチェックしている場合
![image](https://github.com/yusui-okanaka-adglobe-co-jp/2023-Technical-Training-Team-C/assets/130024649/df51a4d2-2552-49c0-b3ab-21cbc5fe246d)

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
