### PR TITLE
削除のみで登録したとき、更新画面に遷移しないバグを修正

### DIFF
--- a/frontend/pages/timetableRegister.vue
+++ b/frontend/pages/timetableRegister.vue
@@ -88,11 +88,10 @@ function useState() {
             isClear: lesson.isClear,
           }
         })
-        .filter((lesson) => lesson.subject.length || lesson.teacher.length)
+        .filter((lesson) => (lesson.subject.length && lesson.teacher.length) || lesson.isClear)
     )
     .flat()
   useTimetables().time.value = { start: start.value, end: end.value }
-
   if (start.value == undefined || end.value == undefined) {
     alert('開始日終了日を選択してください')
   } else if (useTimetables().lessons.value.length === 0) {

--- a/frontend/pages/timetableUpdate.vue
+++ b/frontend/pages/timetableUpdate.vue
@@ -93,9 +93,6 @@ definePageMeta({
 const periodCount: number = 6
 const dayOfWeekCount = [1, 2, 3, 4, 5, 6, 0]
 
-let subjectData: string = ''
-let teacherData: string = ''
-
 const config = useRuntimeConfig()
 
 const { time, lessons } = useTimetables()
@@ -186,19 +183,17 @@ function lessonExist(periodNumber: number, dayOfWeekNumber: number) {
 
 //教科名取得
 function getSubject(periodNumber: number, dayOfWeekNumber: number) {
-  subjectData = String(
-    timetableInfo.filter(({ period }) => period === periodNumber).find(({ dayOfWeek }) => dayOfWeek === dayOfWeekNumber)
-      ?.subject
-  )
-  return subjectData
+  const lesson = timetableInfo
+    .filter(({ period }) => period === periodNumber)
+    .find(({ dayOfWeek }) => dayOfWeek === dayOfWeekNumber)
+  return lesson?.isClear ? '削除' : lesson?.subject
 }
 //教師名取得
 function getTeacher(periodNumber: number, dayOfWeekNumber: number) {
-  teacherData = String(
-    timetableInfo.filter(({ period }) => period === periodNumber).find(({ dayOfWeek }) => dayOfWeek === dayOfWeekNumber)
-      ?.teacher
-  )
-  return teacherData
+  const lesson = timetableInfo
+    .filter(({ period }) => period === periodNumber)
+    .find(({ dayOfWeek }) => dayOfWeek === dayOfWeekNumber)
+  return lesson?.isClear ? '' : lesson?.teacher
 }
 </script>
 


### PR DESCRIPTION
# 関連 Issue

<!-- 関連する Backlog の課題リンクを記載してください -->

https://adglobe.backlog.jp/view/2023_TRAINING_TEAM_C-110

# 変更内容
- 削除のみで登録したとき、更新画面に遷移しないバグを修正
- 更新画面で授業セルに"削除"が表示されないバグを修正
<!-- 変更内容を箇条書きで記載してください -->
<!-- 例:
- xxxテーブルの追加
- yyy画面の登録ボタン押下時の処理をモックから差し替え
- yyy画面のスタイル調整
-->
<!-- また、画面の作成/編集を行った場合はキャプチャを添付してください -->

---

@adg-ShinyaTanaka  
@adglobe-h-omori  
@adglobe-kondo-kazuya  
@kotaro-oka-adglobe-co-jp  
@masaki-shinkawa-adglobe  
@takayuki-miyazaki-adglobe-co-jp
